### PR TITLE
Add 9 investability improvements: streaming, multi-model, audit logging, approvals, pricing, analytics, marketplace, sandboxed execution, white-label

### DIFF
--- a/backend/app/api/agent_router.py
+++ b/backend/app/api/agent_router.py
@@ -1,16 +1,39 @@
-"""API router for the Cornerstone AI Agent web interface."""
+"""API router for the Cornerstone AI Agent web interface.
+
+Includes endpoints for chat, streaming, audit logs, marketplace,
+approval workflows, usage tracking, analytics, and white-label settings.
+"""
 
 from __future__ import annotations
 
+import uuid
+import time
+from datetime import datetime, timezone
 from typing import Any, Optional
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
+from sqlalchemy.orm import Session
+from sqlalchemy import func as sqlfunc
 
 from app.api.deps import get_current_user
 from app.core.config import ANTHROPIC_API_KEY
+from app.core.database import get_db
 from app.models.user import User
-from app.services.agent_service import run_agent_chat, WORKSPACE
+from app.models.agent_audit import AgentAuditLog
+from app.models.agent_config import AgentConfig
+from app.models.subscription import UserSubscription, UsageRecord, PlanTier
+from app.models.platform_settings import PlatformSettings
+from app.services.agent_service import (
+    run_agent_chat,
+    stream_agent_chat_anthropic,
+    get_available_providers,
+    execute_approved_tools,
+    WORKSPACE,
+    MODEL_CONFIGS,
+    TOOL_DEFINITIONS,
+)
 
 router = APIRouter(prefix="/agent", tags=["Cornerstone AI Agent"])
 
@@ -22,18 +45,30 @@ router = APIRouter(prefix="/agent", tags=["Cornerstone AI Agent"])
 class AgentChatRequest(BaseModel):
     message: str
     history: Optional[list[dict[str, Any]]] = None
+    provider: str = "anthropic"
+    model: Optional[str] = None
+    require_approval: bool = False
+    agent_config_id: Optional[int] = None
 
 
 class ToolAction(BaseModel):
     tool: str
     input: dict[str, Any]
     output: str
+    status: str = "executed"
 
 
 class AgentChatResponse(BaseModel):
     response: str
     tool_actions: list[ToolAction]
     history: list[dict[str, Any]]
+    pending_approvals: list[dict[str, Any]] = []
+    tokens_input: int = 0
+    tokens_output: int = 0
+    provider: str = ""
+    model: str = ""
+    session_id: str = ""
+    latency_ms: int = 0
 
 
 class AgentInfoResponse(BaseModel):
@@ -42,6 +77,120 @@ class AgentInfoResponse(BaseModel):
     workspace: str
     tools: list[str]
     status: str
+    providers: list[dict[str, Any]] = []
+    model_configs: dict[str, Any] = {}
+
+
+class ApprovalRequest(BaseModel):
+    approvals: list[dict[str, Any]]
+    approved: bool = True
+
+
+class AgentConfigCreate(BaseModel):
+    name: str
+    description: Optional[str] = None
+    system_prompt: str
+    model_provider: str = "anthropic"
+    model_name: Optional[str] = None
+    tools_enabled: Optional[list[str]] = None
+    max_iterations: int = 10
+    is_public: bool = False
+    category: Optional[str] = None
+    icon: Optional[str] = None
+
+
+class AgentConfigResponse(BaseModel):
+    id: int
+    name: str
+    description: Optional[str]
+    system_prompt: str
+    model_provider: str
+    model_name: str
+    tools_enabled: Optional[list[str]]
+    max_iterations: int
+    created_by: int
+    is_public: bool
+    use_count: int
+    category: Optional[str]
+    icon: Optional[str]
+
+
+class SubscriptionResponse(BaseModel):
+    tier: str
+    messages_used: int
+    messages_limit: int
+    is_active: bool
+
+
+class AuditLogResponse(BaseModel):
+    id: int
+    user_id: int
+    session_id: str
+    message: str
+    response: Optional[str]
+    model_used: str
+    provider: str
+    tool_actions: Optional[Any]
+    tokens_input: int
+    tokens_output: int
+    latency_ms: int
+    status: str
+    created_at: Optional[str]
+
+
+class AnalyticsResponse(BaseModel):
+    total_messages: int
+    total_tool_executions: int
+    total_tokens: int
+    avg_latency_ms: float
+    messages_by_provider: dict[str, int]
+    messages_by_day: list[dict[str, Any]]
+    top_tools: list[dict[str, Any]]
+    active_users: int
+
+
+class PlatformSettingsResponse(BaseModel):
+    platform_name: str
+    tagline: str
+    logo_url: Optional[str]
+    favicon_url: Optional[str]
+    primary_color: str
+    accent_color: str
+    sidebar_bg: str
+    sidebar_text: str
+    custom_css: Optional[str]
+    support_email: Optional[str]
+    enable_marketplace: bool
+    enable_analytics: bool
+
+
+class PlatformSettingsUpdate(BaseModel):
+    platform_name: Optional[str] = None
+    tagline: Optional[str] = None
+    logo_url: Optional[str] = None
+    favicon_url: Optional[str] = None
+    primary_color: Optional[str] = None
+    accent_color: Optional[str] = None
+    sidebar_bg: Optional[str] = None
+    sidebar_text: Optional[str] = None
+    custom_css: Optional[str] = None
+    support_email: Optional[str] = None
+    enable_marketplace: Optional[bool] = None
+    enable_analytics: Optional[bool] = None
+
+
+# ---------------------------------------------------------------------------
+# Helper: ensure subscription exists
+# ---------------------------------------------------------------------------
+
+def _get_or_create_subscription(db: Session, user_id: int) -> UserSubscription:
+    sub = db.query(UserSubscription).filter(UserSubscription.user_id == user_id).first()
+    if not sub:
+        sub = UserSubscription(user_id=user_id, tier=PlanTier.free, messages_used=0, messages_limit=50)
+        db.add(sub)
+        db.commit()
+        db.refresh(sub)
+    return sub
 
 
 # ---------------------------------------------------------------------------
@@ -52,22 +201,117 @@ class AgentInfoResponse(BaseModel):
 def agent_chat(
     payload: AgentChatRequest,
     current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
 ) -> AgentChatResponse:
-    """Send a message to the Cornerstone AI Agent and receive a response.
+    """Send a message to the Cornerstone AI Agent."""
+    # Check usage limits
+    sub = _get_or_create_subscription(db, current_user.id)
+    if sub.messages_limit != -1 and sub.messages_used >= sub.messages_limit:
+        return AgentChatResponse(
+            response="You have reached your monthly message limit. "
+                     "Please upgrade to Pro for unlimited messages.",
+            tool_actions=[], history=payload.history or [],
+        )
 
-    The agent can read/write files, run commands, search code, and manage
-    the project workspace autonomously.  Conversation history can be passed
-    back on subsequent requests to maintain context.
-    """
+    # Load agent config if specified
+    system_prompt = None
+    tools_enabled = None
+    provider = payload.provider
+    model = payload.model
+    if payload.agent_config_id:
+        config = db.query(AgentConfig).filter(AgentConfig.id == payload.agent_config_id).first()
+        if config:
+            system_prompt = config.system_prompt
+            tools_enabled = config.tools_enabled
+            provider = config.model_provider
+            model = model or config.model_name
+            config.use_count = (config.use_count or 0) + 1
+            db.commit()
+
+    start_time = time.time()
     result = run_agent_chat(
         user_message=payload.message,
         history=payload.history,
+        provider=provider,
+        model=model,
+        system_prompt=system_prompt,
+        require_approval=payload.require_approval,
+        tools_enabled=tools_enabled,
     )
+
+    # Record audit log
+    audit = AgentAuditLog(
+        user_id=current_user.id,
+        session_id=result.get("session_id", str(uuid.uuid4())),
+        message=payload.message,
+        response=result["response"][:5000],
+        model_used=result.get("model", ""),
+        provider=result.get("provider", provider),
+        tool_actions=result.get("tool_actions"),
+        tokens_input=result.get("tokens_input", 0),
+        tokens_output=result.get("tokens_output", 0),
+        latency_ms=result.get("latency_ms", 0),
+        status="completed" if not result.get("pending_approvals") else "pending_approval",
+        agent_config_id=payload.agent_config_id,
+    )
+    db.add(audit)
+
+    # Update usage
+    sub.messages_used = (sub.messages_used or 0) + 1
+    usage = UsageRecord(
+        user_id=current_user.id,
+        action_type="agent_chat",
+        model_used=result.get("model", ""),
+        tokens_consumed=result.get("tokens_input", 0) + result.get("tokens_output", 0),
+    )
+    db.add(usage)
+    db.commit()
+
     return AgentChatResponse(
         response=result["response"],
         tool_actions=[ToolAction(**ta) for ta in result["tool_actions"]],
         history=result["history"],
+        pending_approvals=result.get("pending_approvals", []),
+        tokens_input=result.get("tokens_input", 0),
+        tokens_output=result.get("tokens_output", 0),
+        provider=result.get("provider", ""),
+        model=result.get("model", ""),
+        session_id=result.get("session_id", ""),
+        latency_ms=result.get("latency_ms", 0),
     )
+
+
+@router.post("/chat/stream")
+def agent_chat_stream(
+    payload: AgentChatRequest,
+    current_user: User = Depends(get_current_user),
+):
+    """Stream agent responses using Server-Sent Events (SSE)."""
+    return StreamingResponse(
+        stream_agent_chat_anthropic(
+            user_message=payload.message,
+            history=payload.history,
+            model=payload.model,
+        ),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
+@router.post("/approve")
+def approve_tools(
+    payload: ApprovalRequest,
+    current_user: User = Depends(get_current_user),
+):
+    """Approve or reject pending tool executions."""
+    if not payload.approved:
+        return {"status": "rejected", "results": []}
+    results = execute_approved_tools(payload.approvals)
+    return {"status": "approved", "results": results}
 
 
 @router.get("/info", response_model=AgentInfoResponse)
@@ -75,23 +319,281 @@ def agent_info(
     current_user: User = Depends(get_current_user),
 ) -> AgentInfoResponse:
     """Return metadata about the Cornerstone AI Agent."""
+    providers = get_available_providers()
+    any_configured = len(providers) > 0
     return AgentInfoResponse(
         name="Cornerstone AI Agent",
         description=(
-            "An autonomous AI agent powered by Claude that can read, write, "
+            "An autonomous AI agent powered by multiple LLMs that can read, write, "
             "edit, and manage files and run terminal commands inside the "
-            "Cornerstone project workspace."
+            "project workspace. Supports Claude, GPT-4, and Gemini."
         ),
         workspace=WORKSPACE,
-        tools=[
-            "write_file",
-            "read_file",
-            "list_files",
-            "run_command",
-            "delete_file",
-            "create_directory",
-            "search_in_files",
-            "git_status",
-        ],
-        status="online" if ANTHROPIC_API_KEY else "unconfigured",
+        tools=[td["name"] for td in TOOL_DEFINITIONS],
+        status="online" if any_configured else "unconfigured",
+        providers=providers,
+        model_configs=MODEL_CONFIGS,
     )
+
+
+# ---------------------------------------------------------------------------
+# Audit Logs
+# ---------------------------------------------------------------------------
+
+@router.get("/audit")
+def get_audit_logs(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+    limit: int = Query(50, le=200),
+    offset: int = Query(0),
+):
+    """Get agent audit logs for the current user."""
+    logs = (
+        db.query(AgentAuditLog)
+        .filter(AgentAuditLog.user_id == current_user.id)
+        .order_by(AgentAuditLog.created_at.desc())
+        .offset(offset)
+        .limit(limit)
+        .all()
+    )
+    return [
+        {
+            "id": log.id,
+            "session_id": log.session_id,
+            "message": log.message,
+            "response": (log.response or "")[:200],
+            "model_used": log.model_used,
+            "provider": log.provider,
+            "tool_actions": log.tool_actions,
+            "tokens_input": log.tokens_input,
+            "tokens_output": log.tokens_output,
+            "latency_ms": log.latency_ms,
+            "status": log.status,
+            "created_at": str(log.created_at) if log.created_at else None,
+        }
+        for log in logs
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Analytics
+# ---------------------------------------------------------------------------
+
+@router.get("/analytics", response_model=AnalyticsResponse)
+def get_analytics(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Get analytics data for the agent dashboard."""
+    total_messages = db.query(sqlfunc.count(AgentAuditLog.id)).filter(
+        AgentAuditLog.user_id == current_user.id
+    ).scalar() or 0
+
+    total_tokens = db.query(
+        sqlfunc.coalesce(sqlfunc.sum(AgentAuditLog.tokens_input + AgentAuditLog.tokens_output), 0)
+    ).filter(AgentAuditLog.user_id == current_user.id).scalar() or 0
+
+    avg_latency = db.query(
+        sqlfunc.coalesce(sqlfunc.avg(AgentAuditLog.latency_ms), 0)
+    ).filter(AgentAuditLog.user_id == current_user.id).scalar() or 0
+
+    # Messages by provider
+    provider_counts = (
+        db.query(AgentAuditLog.provider, sqlfunc.count(AgentAuditLog.id))
+        .filter(AgentAuditLog.user_id == current_user.id)
+        .group_by(AgentAuditLog.provider)
+        .all()
+    )
+    messages_by_provider = {p: c for p, c in provider_counts if p}
+
+    # Count tool executions from tool_actions JSON
+    total_tool_executions = 0
+    tool_counts: dict[str, int] = {}
+    logs_with_tools = (
+        db.query(AgentAuditLog.tool_actions)
+        .filter(AgentAuditLog.user_id == current_user.id, AgentAuditLog.tool_actions.isnot(None))
+        .all()
+    )
+    for (actions,) in logs_with_tools:
+        if isinstance(actions, list):
+            total_tool_executions += len(actions)
+            for action in actions:
+                if isinstance(action, dict):
+                    name = action.get("tool", "unknown")
+                    tool_counts[name] = tool_counts.get(name, 0) + 1
+
+    top_tools = sorted(
+        [{"tool": k, "count": v} for k, v in tool_counts.items()],
+        key=lambda x: x["count"], reverse=True,
+    )[:10]
+
+    # Active users (org-wide)
+    active_users = db.query(sqlfunc.count(sqlfunc.distinct(AgentAuditLog.user_id))).scalar() or 0
+
+    return AnalyticsResponse(
+        total_messages=total_messages,
+        total_tool_executions=total_tool_executions,
+        total_tokens=total_tokens,
+        avg_latency_ms=round(float(avg_latency), 1),
+        messages_by_provider=messages_by_provider,
+        messages_by_day=[],
+        top_tools=top_tools,
+        active_users=active_users,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Agent Marketplace
+# ---------------------------------------------------------------------------
+
+@router.get("/marketplace")
+def list_marketplace_configs(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+    category: Optional[str] = None,
+):
+    """List public agent configurations and user's own configs."""
+    query = db.query(AgentConfig).filter(
+        (AgentConfig.is_public == True) | (AgentConfig.created_by == current_user.id)
+    )
+    if category:
+        query = query.filter(AgentConfig.category == category)
+    configs = query.order_by(AgentConfig.use_count.desc()).all()
+    return [
+        {
+            "id": c.id, "name": c.name, "description": c.description,
+            "model_provider": c.model_provider, "model_name": c.model_name,
+            "tools_enabled": c.tools_enabled, "max_iterations": c.max_iterations,
+            "created_by": c.created_by, "is_public": c.is_public,
+            "use_count": c.use_count, "category": c.category, "icon": c.icon,
+        }
+        for c in configs
+    ]
+
+
+@router.post("/marketplace")
+def create_marketplace_config(
+    payload: AgentConfigCreate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Create a new agent configuration."""
+    config = AgentConfig(
+        name=payload.name,
+        description=payload.description,
+        system_prompt=payload.system_prompt,
+        model_provider=payload.model_provider,
+        model_name=payload.model_name or MODEL_CONFIGS.get(payload.model_provider, {}).get("default_model", ""),
+        tools_enabled=payload.tools_enabled,
+        max_iterations=payload.max_iterations,
+        created_by=current_user.id,
+        is_public=payload.is_public,
+        category=payload.category,
+        icon=payload.icon,
+    )
+    db.add(config)
+    db.commit()
+    db.refresh(config)
+    return {"id": config.id, "name": config.name, "status": "created"}
+
+
+@router.delete("/marketplace/{config_id}")
+def delete_marketplace_config(
+    config_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Delete an agent configuration (only owner can delete)."""
+    config = db.query(AgentConfig).filter(
+        AgentConfig.id == config_id, AgentConfig.created_by == current_user.id
+    ).first()
+    if not config:
+        return {"error": "Config not found or not authorized"}
+    db.delete(config)
+    db.commit()
+    return {"status": "deleted"}
+
+
+# ---------------------------------------------------------------------------
+# Subscription / Usage
+# ---------------------------------------------------------------------------
+
+@router.get("/subscription", response_model=SubscriptionResponse)
+def get_subscription(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Get current user's subscription info."""
+    sub = _get_or_create_subscription(db, current_user.id)
+    return SubscriptionResponse(
+        tier=sub.tier.value if hasattr(sub.tier, 'value') else str(sub.tier),
+        messages_used=sub.messages_used or 0,
+        messages_limit=sub.messages_limit or 50,
+        is_active=sub.is_active,
+    )
+
+
+@router.post("/subscription/upgrade")
+def upgrade_subscription(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Upgrade to Pro tier (placeholder - would integrate with Stripe)."""
+    sub = _get_or_create_subscription(db, current_user.id)
+    sub.tier = PlanTier.pro
+    sub.messages_limit = -1  # unlimited
+    db.commit()
+    return {"status": "upgraded", "tier": "pro", "messages_limit": -1}
+
+
+# ---------------------------------------------------------------------------
+# White-Label / Platform Settings
+# ---------------------------------------------------------------------------
+
+@router.get("/settings", response_model=PlatformSettingsResponse)
+def get_platform_settings(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Get platform branding/settings."""
+    settings = db.query(PlatformSettings).first()
+    if not settings:
+        settings = PlatformSettings()
+        db.add(settings)
+        db.commit()
+        db.refresh(settings)
+    return PlatformSettingsResponse(
+        platform_name=settings.platform_name or "NorthStar",
+        tagline=settings.tagline or "AI-Powered Consulting Platform",
+        logo_url=settings.logo_url,
+        favicon_url=settings.favicon_url,
+        primary_color=settings.primary_color or "#3182ce",
+        accent_color=settings.accent_color or "#805ad5",
+        sidebar_bg=settings.sidebar_bg or "#1a202c",
+        sidebar_text=settings.sidebar_text or "#90cdf4",
+        custom_css=settings.custom_css,
+        support_email=settings.support_email,
+        enable_marketplace=settings.enable_marketplace if settings.enable_marketplace is not None else True,
+        enable_analytics=settings.enable_analytics if settings.enable_analytics is not None else True,
+    )
+
+
+@router.put("/settings")
+def update_platform_settings(
+    payload: PlatformSettingsUpdate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    """Update platform branding/settings."""
+    settings = db.query(PlatformSettings).first()
+    if not settings:
+        settings = PlatformSettings()
+        db.add(settings)
+        db.commit()
+        db.refresh(settings)
+
+    update_data = payload.model_dump(exclude_unset=True)
+    for key, value in update_data.items():
+        setattr(settings, key, value)
+    db.commit()
+    return {"status": "updated"}

--- a/backend/app/api/agent_router.py
+++ b/backend/app/api/agent_router.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 
 from app.api.deps import get_current_user
+from app.core.config import ANTHROPIC_API_KEY
 from app.models.user import User
 from app.services.agent_service import run_agent_chat, WORKSPACE
 
@@ -92,5 +93,5 @@ def agent_info(
             "search_in_files",
             "git_status",
         ],
-        status="online",
+        status="online" if ANTHROPIC_API_KEY else "unconfigured",
     )

--- a/backend/app/api/agent_router.py
+++ b/backend/app/api/agent_router.py
@@ -437,22 +437,25 @@ def get_analytics(
 
     # Compute messages_by_day (last 30 days)
     from datetime import timedelta
+    from collections import Counter
     now = datetime.now(timezone.utc)
     thirty_days_ago = now - timedelta(days=30)
-    daily_rows = (
-        db.query(
-            sqlfunc.cast(AgentAuditLog.created_at, sqlfunc.text()).label("day"),
-            sqlfunc.count(AgentAuditLog.id).label("cnt"),
-        )
+    recent_logs = (
+        db.query(AgentAuditLog.created_at)
         .filter(
             AgentAuditLog.user_id == current_user.id,
             AgentAuditLog.created_at >= thirty_days_ago,
         )
-        .group_by("day")
-        .order_by("day")
         .all()
     )
-    messages_by_day = [{"date": str(row.day)[:10], "count": row.cnt} for row in daily_rows]
+    day_counter: Counter[str] = Counter()
+    for (ts,) in recent_logs:
+        if ts:
+            day_counter[str(ts)[:10]] += 1
+    messages_by_day = sorted(
+        [{"date": d, "count": c} for d, c in day_counter.items()],
+        key=lambda x: x["date"],
+    )
 
     return AnalyticsResponse(
         total_messages=total_messages,

--- a/backend/app/api/agent_router.py
+++ b/backend/app/api/agent_router.py
@@ -1,0 +1,96 @@
+"""API router for the Cornerstone AI Agent web interface."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from app.api.deps import get_current_user
+from app.models.user import User
+from app.services.agent_service import run_agent_chat, WORKSPACE
+
+router = APIRouter(prefix="/agent", tags=["Cornerstone AI Agent"])
+
+
+# ---------------------------------------------------------------------------
+# Request / Response schemas
+# ---------------------------------------------------------------------------
+
+class AgentChatRequest(BaseModel):
+    message: str
+    history: Optional[list[dict[str, Any]]] = None
+
+
+class ToolAction(BaseModel):
+    tool: str
+    input: dict[str, Any]
+    output: str
+
+
+class AgentChatResponse(BaseModel):
+    response: str
+    tool_actions: list[ToolAction]
+    history: list[dict[str, Any]]
+
+
+class AgentInfoResponse(BaseModel):
+    name: str
+    description: str
+    workspace: str
+    tools: list[str]
+    status: str
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+@router.post("/chat", response_model=AgentChatResponse)
+def agent_chat(
+    payload: AgentChatRequest,
+    current_user: User = Depends(get_current_user),
+) -> AgentChatResponse:
+    """Send a message to the Cornerstone AI Agent and receive a response.
+
+    The agent can read/write files, run commands, search code, and manage
+    the project workspace autonomously.  Conversation history can be passed
+    back on subsequent requests to maintain context.
+    """
+    result = run_agent_chat(
+        user_message=payload.message,
+        history=payload.history,
+    )
+    return AgentChatResponse(
+        response=result["response"],
+        tool_actions=[ToolAction(**ta) for ta in result["tool_actions"]],
+        history=result["history"],
+    )
+
+
+@router.get("/info", response_model=AgentInfoResponse)
+def agent_info(
+    current_user: User = Depends(get_current_user),
+) -> AgentInfoResponse:
+    """Return metadata about the Cornerstone AI Agent."""
+    return AgentInfoResponse(
+        name="Cornerstone AI Agent",
+        description=(
+            "An autonomous AI agent powered by Claude that can read, write, "
+            "edit, and manage files and run terminal commands inside the "
+            "Cornerstone project workspace."
+        ),
+        workspace=WORKSPACE,
+        tools=[
+            "write_file",
+            "read_file",
+            "list_files",
+            "run_command",
+            "delete_file",
+            "create_directory",
+            "search_in_files",
+            "git_status",
+        ],
+        status="online",
+    )

--- a/backend/app/api/agent_router.py
+++ b/backend/app/api/agent_router.py
@@ -309,9 +309,14 @@ def approve_tools(
 ):
     """Approve or reject pending tool executions."""
     if not payload.approved:
-        return {"status": "rejected", "results": []}
+        return {"status": "rejected", "response": "Actions cancelled.", "tool_actions": [], "results": []}
     results = execute_approved_tools(payload.approvals)
-    return {"status": "approved", "results": results}
+    # Build a summary response from tool results
+    summary_parts = []
+    for r in results:
+        summary_parts.append(f"Executed {r['tool']}: {r['output'][:200]}")
+    response_text = "\n".join(summary_parts) if summary_parts else "Actions approved and executed."
+    return {"status": "approved", "response": response_text, "tool_actions": results, "results": results}
 
 
 @router.get("/info", response_model=AgentInfoResponse)
@@ -430,13 +435,32 @@ def get_analytics(
     # Active users (org-wide)
     active_users = db.query(sqlfunc.count(sqlfunc.distinct(AgentAuditLog.user_id))).scalar() or 0
 
+    # Compute messages_by_day (last 30 days)
+    from datetime import timedelta
+    now = datetime.now(timezone.utc)
+    thirty_days_ago = now - timedelta(days=30)
+    daily_rows = (
+        db.query(
+            sqlfunc.cast(AgentAuditLog.created_at, sqlfunc.text()).label("day"),
+            sqlfunc.count(AgentAuditLog.id).label("cnt"),
+        )
+        .filter(
+            AgentAuditLog.user_id == current_user.id,
+            AgentAuditLog.created_at >= thirty_days_ago,
+        )
+        .group_by("day")
+        .order_by("day")
+        .all()
+    )
+    messages_by_day = [{"date": str(row.day)[:10], "count": row.cnt} for row in daily_rows]
+
     return AnalyticsResponse(
         total_messages=total_messages,
         total_tool_executions=total_tool_executions,
         total_tokens=total_tokens,
         avg_latency_ms=round(float(avg_latency), 1),
         messages_by_provider=messages_by_provider,
-        messages_by_day=[],
+        messages_by_day=messages_by_day,
         top_tools=top_tools,
         active_users=active_users,
     )
@@ -596,4 +620,18 @@ def update_platform_settings(
     for key, value in update_data.items():
         setattr(settings, key, value)
     db.commit()
-    return {"status": "updated"}
+    db.refresh(settings)
+    return PlatformSettingsResponse(
+        platform_name=settings.platform_name or "NorthStar",
+        tagline=settings.tagline or "AI-Powered Consulting Platform",
+        logo_url=settings.logo_url,
+        favicon_url=settings.favicon_url,
+        primary_color=settings.primary_color or "#3182ce",
+        accent_color=settings.accent_color or "#805ad5",
+        sidebar_bg=settings.sidebar_bg or "#1a202c",
+        sidebar_text=settings.sidebar_text or "#90cdf4",
+        custom_css=settings.custom_css,
+        support_email=settings.support_email,
+        enable_marketplace=settings.enable_marketplace if settings.enable_marketplace is not None else True,
+        enable_analytics=settings.enable_analytics if settings.enable_analytics is not None else True,
+    )

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -11,6 +11,7 @@ ACCESS_TOKEN_EXPIRE_MINUTES: int = 30
 REFRESH_TOKEN_EXPIRE_DAYS: int = 7
 SERPAPI_KEY: str = os.getenv("SERPAPI_KEY", "")
 OPENAI_API_KEY: str = os.getenv("OPENAI_API_KEY", "")
+ANTHROPIC_API_KEY: str = os.getenv("ANTHROPIC_API_KEY", "")
 CORS_ORIGINS: list[str] = [
     o.strip()
     for o in os.getenv("CORS_ORIGINS", "http://localhost:3000").split(",")

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -12,6 +12,7 @@ REFRESH_TOKEN_EXPIRE_DAYS: int = 7
 SERPAPI_KEY: str = os.getenv("SERPAPI_KEY", "")
 OPENAI_API_KEY: str = os.getenv("OPENAI_API_KEY", "")
 ANTHROPIC_API_KEY: str = os.getenv("ANTHROPIC_API_KEY", "")
+GOOGLE_API_KEY: str = os.getenv("GOOGLE_API_KEY", "")
 CORS_ORIGINS: list[str] = [
     o.strip()
     for o in os.getenv("CORS_ORIGINS", "http://localhost:3000").split(",")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,6 +9,7 @@ from app.api.funding_router import router as funding_router
 from app.api.research_router import router as research_router
 from app.api.rewards_router import router as rewards_router
 from app.api.business_ideas_router import router as business_ideas_router
+from app.api.agent_router import router as agent_router
 from app.core.config import CORS_ORIGINS
 
 app = FastAPI(
@@ -33,6 +34,7 @@ app.include_router(funding_router)
 app.include_router(research_router)
 app.include_router(rewards_router)
 app.include_router(business_ideas_router)
+app.include_router(agent_router)
 
 
 @app.get("/")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,14 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from app.core.database import engine, Base
+# Import all models so they register with Base.metadata
+from app.models.user import User  # noqa: F401
+from app.models.agent_audit import AgentAuditLog  # noqa: F401
+from app.models.agent_config import AgentConfig  # noqa: F401
+from app.models.subscription import UserSubscription, UsageRecord  # noqa: F401
+from app.models.platform_settings import PlatformSettings  # noqa: F401
+
 from app.api.auth_router import router as auth_router
 from app.api.leads_router import router as leads_router
 from app.api.outreach_router import router as outreach_router
@@ -37,6 +45,12 @@ app.include_router(business_ideas_router)
 app.include_router(agent_router)
 
 
+@app.on_event("startup")
+def on_startup():
+    """Create database tables for new models on startup."""
+    Base.metadata.create_all(bind=engine)
+
+
 @app.get("/")
 def health_check():
-    return {"status": "ok", "platform": "NorthStar", "version": "0.4.0"}
+    return {"status": "ok", "platform": "NorthStar", "version": "0.5.0"}

--- a/backend/app/models/agent_audit.py
+++ b/backend/app/models/agent_audit.py
@@ -1,0 +1,27 @@
+"""Audit logging for Cornerstone AI Agent interactions."""
+
+import enum
+from sqlalchemy import Column, Integer, String, Float, Text, DateTime, ForeignKey, Enum, JSON
+from sqlalchemy.sql import func
+
+from app.core.database import Base
+
+
+class AgentAuditLog(Base):
+    __tablename__ = "agent_audit_logs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
+    session_id = Column(String, nullable=False, index=True)
+    message = Column(Text, nullable=False)
+    response = Column(Text, nullable=True)
+    model_used = Column(String, nullable=False)
+    provider = Column(String, nullable=False)  # anthropic, openai, google
+    tool_actions = Column(JSON, nullable=True)
+    tokens_input = Column(Integer, default=0)
+    tokens_output = Column(Integer, default=0)
+    latency_ms = Column(Integer, default=0)
+    status = Column(String, default="completed")  # completed, error, pending_approval
+    error_message = Column(Text, nullable=True)
+    agent_config_id = Column(Integer, ForeignKey("agent_configs.id"), nullable=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())

--- a/backend/app/models/agent_config.py
+++ b/backend/app/models/agent_config.py
@@ -1,0 +1,26 @@
+"""Agent marketplace configurations."""
+
+from sqlalchemy import Column, Integer, String, Boolean, Text, DateTime, ForeignKey, JSON
+from sqlalchemy.sql import func
+
+from app.core.database import Base
+
+
+class AgentConfig(Base):
+    __tablename__ = "agent_configs"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, nullable=False, index=True)
+    description = Column(Text, nullable=True)
+    system_prompt = Column(Text, nullable=False)
+    model_provider = Column(String, default="anthropic")  # anthropic, openai, google
+    model_name = Column(String, default="claude-sonnet-4-20250514")
+    tools_enabled = Column(JSON, nullable=True)  # list of tool names, null = all
+    max_iterations = Column(Integer, default=10)
+    created_by = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
+    is_public = Column(Boolean, default=False)
+    use_count = Column(Integer, default=0)
+    category = Column(String, nullable=True)  # coding, devops, data, general
+    icon = Column(String, nullable=True)  # emoji or icon name
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())

--- a/backend/app/models/platform_settings.py
+++ b/backend/app/models/platform_settings.py
@@ -1,0 +1,25 @@
+"""White-label platform settings."""
+
+from sqlalchemy import Column, Integer, String, Text, DateTime, Boolean
+from sqlalchemy.sql import func
+
+from app.core.database import Base
+
+
+class PlatformSettings(Base):
+    __tablename__ = "platform_settings"
+
+    id = Column(Integer, primary_key=True, index=True)
+    platform_name = Column(String, default="NorthStar")
+    tagline = Column(String, default="AI-Powered Consulting Platform")
+    logo_url = Column(String, nullable=True)
+    favicon_url = Column(String, nullable=True)
+    primary_color = Column(String, default="#3182ce")
+    accent_color = Column(String, default="#805ad5")
+    sidebar_bg = Column(String, default="#1a202c")
+    sidebar_text = Column(String, default="#90cdf4")
+    custom_css = Column(Text, nullable=True)
+    support_email = Column(String, nullable=True)
+    enable_marketplace = Column(Boolean, default=True)
+    enable_analytics = Column(Boolean, default=True)
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())

--- a/backend/app/models/subscription.py
+++ b/backend/app/models/subscription.py
@@ -1,0 +1,40 @@
+"""User subscriptions and usage tracking for tiered pricing."""
+
+import enum
+from sqlalchemy import Column, Integer, String, Float, DateTime, ForeignKey, Enum, Boolean
+from sqlalchemy.sql import func
+
+from app.core.database import Base
+
+
+class PlanTier(str, enum.Enum):
+    free = "free"
+    pro = "pro"
+    enterprise = "enterprise"
+
+
+class UserSubscription(Base):
+    __tablename__ = "user_subscriptions"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"), unique=True, nullable=False, index=True)
+    tier = Column(Enum(PlanTier), default=PlanTier.free, nullable=False)
+    messages_used = Column(Integer, default=0)
+    messages_limit = Column(Integer, default=50)  # free=50, pro=unlimited(-1), enterprise=custom
+    billing_cycle_start = Column(DateTime(timezone=True), server_default=func.now())
+    stripe_customer_id = Column(String, nullable=True)
+    stripe_subscription_id = Column(String, nullable=True)
+    is_active = Column(Boolean, default=True)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+
+
+class UsageRecord(Base):
+    __tablename__ = "usage_records"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False, index=True)
+    action_type = Column(String, nullable=False)  # agent_chat, tool_execution
+    model_used = Column(String, nullable=True)
+    tokens_consumed = Column(Integer, default=0)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())

--- a/backend/app/services/agent_service.py
+++ b/backend/app/services/agent_service.py
@@ -1,0 +1,380 @@
+"""Service layer for the Cornerstone AI Agent web integration.
+
+Adapts the CLI-based Cornerstone AI Agent to work via HTTP by providing
+a stateless chat endpoint.  Each request runs the agent loop once and
+returns the assistant's text response along with any tool actions that
+were executed.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from typing import Any
+
+import anthropic
+
+from app.core.config import ANTHROPIC_API_KEY
+
+# ---------------------------------------------------------------------------
+# Agent configuration
+# ---------------------------------------------------------------------------
+
+WORKSPACE: str = os.path.abspath(
+    os.getenv("AGENT_WORKSPACE", os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+)
+
+SYSTEM_PROMPT = (
+    "You are an expert senior software engineer working on the "
+    "Cornerstone Platform \u2014 a FastAPI + PostgreSQL backend project. "
+    "You have direct access to the project workspace and can read, "
+    "write, create, delete files, run commands, and search code.\n\n"
+    "Rules:\n"
+    "- Always read a file before overwriting it.\n"
+    "- Never delete files unless the user explicitly requests it.\n"
+    "- Always explain what you are about to do in plain English "
+    "before using a tool.\n"
+    "- Write clean, production-quality Python code.\n"
+    "- Follow the existing project structure and conventions.\n"
+    "- After completing a task, summarize what you did."
+)
+
+MODEL = "claude-sonnet-4-20250514"
+MAX_TOKENS = 4096
+
+# ---------------------------------------------------------------------------
+# Blocked commands (safety)
+# ---------------------------------------------------------------------------
+
+BLOCKED_COMMANDS: list[str] = [
+    "rm -rf /",
+    "format",
+    "del /f /s /q C:\\",
+    "shutdown",
+    "DROP DATABASE",
+    "DROP TABLE",
+    ":(){:|:&};:",
+]
+
+
+def _is_blocked(command: str) -> bool:
+    cmd_lower = command.lower()
+    return any(b.lower() in cmd_lower for b in BLOCKED_COMMANDS)
+
+
+# ---------------------------------------------------------------------------
+# Tool implementations (sandboxed to WORKSPACE)
+# ---------------------------------------------------------------------------
+
+def _write_file(filepath: str, content: str) -> str:
+    full = os.path.join(WORKSPACE, filepath)
+    os.makedirs(os.path.dirname(full), exist_ok=True)
+    with open(full, "w", encoding="utf-8") as fh:
+        fh.write(content)
+    return f"Successfully wrote {len(content)} characters to {filepath}"
+
+
+def _read_file(filepath: str) -> str:
+    full = os.path.join(WORKSPACE, filepath)
+    if not os.path.isfile(full):
+        return f"Error: file not found \u2014 {filepath}"
+    with open(full, "r", encoding="utf-8") as fh:
+        return fh.read()
+
+
+def _list_files(directory: str = ".") -> str:
+    full = os.path.join(WORKSPACE, directory)
+    if not os.path.isdir(full):
+        return f"Error: directory not found \u2014 {directory}"
+    files: list[str] = []
+    for root, _dirs, filenames in os.walk(full):
+        for name in filenames:
+            rel = os.path.relpath(os.path.join(root, name), WORKSPACE)
+            files.append(rel)
+    files.sort()
+    return "\n".join(files[:200]) if files else "(empty directory)"
+
+
+def _run_command(command: str) -> str:
+    if _is_blocked(command):
+        return f"BLOCKED: '{command}' matches a dangerous pattern."
+    result = subprocess.run(
+        command, shell=True, cwd=WORKSPACE,
+        capture_output=True, text=True, timeout=60,
+    )
+    output = ""
+    if result.stdout:
+        output += result.stdout
+    if result.stderr:
+        output += ("\n" if output else "") + result.stderr
+    return output[:5000] or "(no output)"
+
+
+def _delete_file(filepath: str) -> str:
+    full = os.path.join(WORKSPACE, filepath)
+    if not os.path.isfile(full):
+        return f"Error: file not found \u2014 {filepath}"
+    os.remove(full)
+    return f"Successfully deleted {filepath}"
+
+
+def _create_directory(directory: str) -> str:
+    full = os.path.join(WORKSPACE, directory)
+    os.makedirs(full, exist_ok=True)
+    return f"Successfully created directory {directory}"
+
+
+def _search_in_files(pattern: str, directory: str = ".") -> str:
+    full = os.path.join(WORKSPACE, directory)
+    if not os.path.isdir(full):
+        return f"Error: directory not found \u2014 {directory}"
+    matches: list[str] = []
+    for root, _dirs, filenames in os.walk(full):
+        for name in filenames:
+            fpath = os.path.join(root, name)
+            try:
+                with open(fpath, "r", encoding="utf-8", errors="ignore") as fh:
+                    for lineno, line in enumerate(fh, start=1):
+                        if pattern in line:
+                            rel = os.path.relpath(fpath, WORKSPACE)
+                            matches.append(f"{rel}:{lineno}: {line.rstrip()}")
+                            if len(matches) >= 50:
+                                matches.append("... (truncated at 50)")
+                                return "\n".join(matches)
+            except (OSError, UnicodeDecodeError):
+                continue
+    return "\n".join(matches) if matches else "No matches found."
+
+
+def _git_status() -> str:
+    st = subprocess.run(
+        "git status", shell=True, cwd=WORKSPACE,
+        capture_output=True, text=True, timeout=30,
+    )
+    diff = subprocess.run(
+        "git diff --stat", shell=True, cwd=WORKSPACE,
+        capture_output=True, text=True, timeout=30,
+    )
+    output = st.stdout
+    if diff.stdout:
+        output += "\n" + diff.stdout
+    return output or "(no git output)"
+
+
+# ---------------------------------------------------------------------------
+# Tool schema + dispatcher
+# ---------------------------------------------------------------------------
+
+_TOOL_MAP: dict[str, Any] = {
+    "write_file": _write_file,
+    "read_file": _read_file,
+    "list_files": _list_files,
+    "run_command": _run_command,
+    "delete_file": _delete_file,
+    "create_directory": _create_directory,
+    "search_in_files": _search_in_files,
+    "git_status": _git_status,
+}
+
+TOOL_DEFINITIONS: list[dict[str, Any]] = [
+    {
+        "name": "write_file",
+        "description": "Write content to a file relative to the workspace.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "filepath": {"type": "string", "description": "Path relative to workspace."},
+                "content": {"type": "string", "description": "Content to write."},
+            },
+            "required": ["filepath", "content"],
+        },
+    },
+    {
+        "name": "read_file",
+        "description": "Read and return a file's contents.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "filepath": {"type": "string", "description": "Path relative to workspace."},
+            },
+            "required": ["filepath"],
+        },
+    },
+    {
+        "name": "list_files",
+        "description": "Recursively list files in a directory.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "directory": {"type": "string", "description": "Directory path (default: '.').", "default": "."},
+            },
+            "required": [],
+        },
+    },
+    {
+        "name": "run_command",
+        "description": "Run a shell command inside the workspace (60 s timeout).",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "command": {"type": "string", "description": "Shell command to execute."},
+            },
+            "required": ["command"],
+        },
+    },
+    {
+        "name": "delete_file",
+        "description": "Delete a file relative to the workspace.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "filepath": {"type": "string", "description": "Path relative to workspace."},
+            },
+            "required": ["filepath"],
+        },
+    },
+    {
+        "name": "create_directory",
+        "description": "Create a directory (and parents) relative to the workspace.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "directory": {"type": "string", "description": "Directory path to create."},
+            },
+            "required": ["directory"],
+        },
+    },
+    {
+        "name": "search_in_files",
+        "description": "Search for a text pattern across files (max 50 results).",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "pattern": {"type": "string", "description": "Text pattern to search for."},
+                "directory": {"type": "string", "description": "Directory to search (default: '.').", "default": "."},
+            },
+            "required": ["pattern"],
+        },
+    },
+    {
+        "name": "git_status",
+        "description": "Run git status and git diff --stat.",
+        "input_schema": {
+            "type": "object",
+            "properties": {},
+            "required": [],
+        },
+    },
+]
+
+
+def _execute_tool(tool_name: str, tool_input: dict[str, Any]) -> str:
+    func = _TOOL_MAP.get(tool_name)
+    if func is None:
+        return f"Error: unknown tool '{tool_name}'"
+    try:
+        return func(**tool_input)
+    except Exception as exc:
+        return f"Error executing {tool_name}: {exc}"
+
+
+def _make_serializable(obj: Any) -> Any:
+    if hasattr(obj, "model_dump"):
+        return obj.model_dump()
+    if isinstance(obj, list):
+        return [_make_serializable(item) for item in obj]
+    if isinstance(obj, dict):
+        return {k: _make_serializable(v) for k, v in obj.items()}
+    return obj
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def run_agent_chat(
+    user_message: str,
+    history: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Run a single turn of the Cornerstone AI Agent.
+
+    Parameters
+    ----------
+    user_message:
+        The latest message from the user.
+    history:
+        Optional conversation history (list of ``{"role": ..., "content": ...}``).
+
+    Returns
+    -------
+    dict with keys:
+        ``response``  - the agent's text reply
+        ``tool_actions`` - list of tool calls that were executed
+        ``history``   - updated conversation history (for follow-up calls)
+    """
+    api_key = ANTHROPIC_API_KEY
+    if not api_key:
+        return {
+            "response": "The Cornerstone AI Agent is not configured. "
+                        "Please set the ANTHROPIC_API_KEY environment variable.",
+            "tool_actions": [],
+            "history": history or [],
+        }
+
+    client = anthropic.Anthropic(api_key=api_key)
+
+    messages: list[dict[str, Any]] = list(history) if history else []
+    messages.append({"role": "user", "content": user_message})
+
+    tool_actions: list[dict[str, Any]] = []
+    assistant_text_parts: list[str] = []
+
+    # Agent loop (max 10 iterations to prevent runaway loops)
+    for _ in range(10):
+        response = client.messages.create(
+            model=MODEL,
+            max_tokens=MAX_TOKENS,
+            system=SYSTEM_PROMPT,
+            tools=TOOL_DEFINITIONS,
+            messages=messages,
+        )
+
+        serialized_content = _make_serializable(response.content)
+        messages.append({"role": "assistant", "content": serialized_content})
+
+        # Collect text blocks
+        for block in response.content:
+            if hasattr(block, "text"):
+                assistant_text_parts.append(block.text)
+
+        if response.stop_reason == "end_turn":
+            break
+
+        if response.stop_reason == "tool_use":
+            tool_results: list[dict[str, Any]] = []
+            for block in response.content:
+                if block.type != "tool_use":
+                    continue
+
+                result = _execute_tool(block.name, block.input)
+                tool_actions.append({
+                    "tool": block.name,
+                    "input": block.input,
+                    "output": result[:2000],
+                })
+                tool_results.append({
+                    "type": "tool_result",
+                    "tool_use_id": block.id,
+                    "content": result,
+                })
+
+            messages.append({"role": "user", "content": tool_results})
+        else:
+            break
+
+    return {
+        "response": "\n\n".join(assistant_text_parts),
+        "tool_actions": tool_actions,
+        "history": messages,
+    }

--- a/backend/app/services/agent_service.py
+++ b/backend/app/services/agent_service.py
@@ -1,20 +1,22 @@
 """Service layer for the Cornerstone AI Agent web integration.
 
-Adapts the CLI-based Cornerstone AI Agent to work via HTTP by providing
-a stateless chat endpoint.  Each request runs the agent loop once and
-returns the assistant's text response along with any tool actions that
-were executed.
+Supports multiple AI providers (Anthropic, OpenAI, Google), streaming responses,
+audit logging, approval workflows, and usage tracking.
 """
 
 from __future__ import annotations
 
 import os
 import subprocess
-from typing import Any
+import time
+import uuid
+import json
+from typing import Any, Generator
 
 import anthropic
+import openai
 
-from app.core.config import ANTHROPIC_API_KEY
+from app.core.config import ANTHROPIC_API_KEY, OPENAI_API_KEY
 
 # ---------------------------------------------------------------------------
 # Agent configuration
@@ -24,7 +26,9 @@ WORKSPACE: str = os.path.abspath(
     os.getenv("AGENT_WORKSPACE", os.path.join(os.path.dirname(__file__), "..", "..", ".."))
 )
 
-SYSTEM_PROMPT = (
+GOOGLE_API_KEY: str = os.getenv("GOOGLE_API_KEY", "")
+
+DEFAULT_SYSTEM_PROMPT = (
     "You are an expert senior software engineer working on the "
     "Cornerstone Platform \u2014 a FastAPI + PostgreSQL backend project. "
     "You have direct access to the project workspace and can read, "
@@ -39,35 +43,44 @@ SYSTEM_PROMPT = (
     "- After completing a task, summarize what you did."
 )
 
-MODEL = "claude-sonnet-4-20250514"
-MAX_TOKENS = 4096
+MODEL_CONFIGS: dict[str, dict[str, Any]] = {
+    "anthropic": {
+        "default_model": "claude-sonnet-4-20250514",
+        "models": ["claude-sonnet-4-20250514", "claude-3-5-haiku-20241022"],
+        "max_tokens": 4096,
+    },
+    "openai": {
+        "default_model": "gpt-4o",
+        "models": ["gpt-4o", "gpt-4o-mini", "gpt-4-turbo"],
+        "max_tokens": 4096,
+    },
+    "google": {
+        "default_model": "gemini-2.0-flash",
+        "models": ["gemini-2.0-flash", "gemini-1.5-pro"],
+        "max_tokens": 4096,
+    },
+}
 
-# ---------------------------------------------------------------------------
-# Blocked commands (safety)
-# ---------------------------------------------------------------------------
-
-BLOCKED_COMMANDS: list[str] = [
-    "rm -rf /",
-    "format",
-    "del /f /s /q C:\\",
-    "shutdown",
-    "DROP DATABASE",
-    "DROP TABLE",
-    ":(){:|:&};:",
+BLOCKED_PATTERNS: list[str] = [
+    "rm -rf /", "rm -r -f /", "rm -rf /*", "format c:",
+    "del /f /s /q c:\\", "shutdown", "reboot", "halt",
+    "drop database", "drop table", "truncate table",
+    ":(){:|:&};:", "mkfs", "dd if=", "> /dev/sda",
+    "chmod -r 777 /", "curl | bash", "curl | sh",
+    "wget | bash", "wget | sh",
 ]
 
 
 def _is_blocked(command: str) -> bool:
-    cmd_lower = command.lower()
-    return any(b.lower() in cmd_lower for b in BLOCKED_COMMANDS)
+    cmd_lower = command.lower().strip()
+    return any(b.lower() in cmd_lower for b in BLOCKED_PATTERNS)
 
 
-# ---------------------------------------------------------------------------
-# Tool implementations (sandboxed to WORKSPACE)
-# ---------------------------------------------------------------------------
+DESTRUCTIVE_TOOLS = {"write_file", "delete_file", "run_command", "create_directory"}
+SAFE_TOOLS = {"read_file", "list_files", "search_in_files", "git_status"}
+
 
 def _resolve_safe(path: str) -> str:
-    """Resolve *path* relative to WORKSPACE and verify it stays inside."""
     resolved = os.path.realpath(os.path.join(WORKSPACE, path))
     if not resolved.startswith(os.path.realpath(WORKSPACE) + os.sep) and resolved != os.path.realpath(WORKSPACE):
         raise PermissionError(f"Path escapes workspace: {path}")
@@ -85,7 +98,7 @@ def _write_file(filepath: str, content: str) -> str:
 def _read_file(filepath: str) -> str:
     full = _resolve_safe(filepath)
     if not os.path.isfile(full):
-        return f"Error: file not found \u2014 {filepath}"
+        return f"Error: file not found - {filepath}"
     with open(full, "r", encoding="utf-8") as fh:
         return fh.read()
 
@@ -93,7 +106,7 @@ def _read_file(filepath: str) -> str:
 def _list_files(directory: str = ".") -> str:
     full = _resolve_safe(directory)
     if not os.path.isdir(full):
-        return f"Error: directory not found \u2014 {directory}"
+        return f"Error: directory not found - {directory}"
     files: list[str] = []
     for root, _dirs, filenames in os.walk(full):
         for name in filenames:
@@ -105,7 +118,7 @@ def _list_files(directory: str = ".") -> str:
 
 def _run_command(command: str) -> str:
     if _is_blocked(command):
-        return f"BLOCKED: '{command}' matches a dangerous pattern."
+        return f"BLOCKED: \'{command}\' matches a dangerous pattern."
     result = subprocess.run(
         command, shell=True, cwd=WORKSPACE,
         capture_output=True, text=True, timeout=60,
@@ -121,7 +134,7 @@ def _run_command(command: str) -> str:
 def _delete_file(filepath: str) -> str:
     full = _resolve_safe(filepath)
     if not os.path.isfile(full):
-        return f"Error: file not found \u2014 {filepath}"
+        return f"Error: file not found - {filepath}"
     os.remove(full)
     return f"Successfully deleted {filepath}"
 
@@ -135,7 +148,7 @@ def _create_directory(directory: str) -> str:
 def _search_in_files(pattern: str, directory: str = ".") -> str:
     full = _resolve_safe(directory)
     if not os.path.isdir(full):
-        return f"Error: directory not found \u2014 {directory}"
+        return f"Error: directory not found - {directory}"
     matches: list[str] = []
     for root, _dirs, filenames in os.walk(full):
         for name in filenames:
@@ -169,10 +182,6 @@ def _git_status() -> str:
     return output or "(no git output)"
 
 
-# ---------------------------------------------------------------------------
-# Tool schema + dispatcher
-# ---------------------------------------------------------------------------
-
 _TOOL_MAP: dict[str, Any] = {
     "write_file": _write_file,
     "read_file": _read_file,
@@ -199,7 +208,7 @@ TOOL_DEFINITIONS: list[dict[str, Any]] = [
     },
     {
         "name": "read_file",
-        "description": "Read and return a file's contents.",
+        "description": "Read and return a file\'s contents.",
         "input_schema": {
             "type": "object",
             "properties": {
@@ -214,7 +223,7 @@ TOOL_DEFINITIONS: list[dict[str, Any]] = [
         "input_schema": {
             "type": "object",
             "properties": {
-                "directory": {"type": "string", "description": "Directory path (default: '.').", "default": "."},
+                "directory": {"type": "string", "description": "Directory path (default: \'.\').", "default": "."},
             },
             "required": [],
         },
@@ -259,7 +268,7 @@ TOOL_DEFINITIONS: list[dict[str, Any]] = [
             "type": "object",
             "properties": {
                 "pattern": {"type": "string", "description": "Text pattern to search for."},
-                "directory": {"type": "string", "description": "Directory to search (default: '.').", "default": "."},
+                "directory": {"type": "string", "description": "Directory to search (default: \'.\').", "default": "."},
             },
             "required": ["pattern"],
         },
@@ -275,11 +284,23 @@ TOOL_DEFINITIONS: list[dict[str, Any]] = [
     },
 ]
 
+OPENAI_TOOL_DEFINITIONS: list[dict[str, Any]] = [
+    {
+        "type": "function",
+        "function": {
+            "name": td["name"],
+            "description": td["description"],
+            "parameters": td["input_schema"],
+        },
+    }
+    for td in TOOL_DEFINITIONS
+]
+
 
 def _execute_tool(tool_name: str, tool_input: dict[str, Any]) -> str:
     func = _TOOL_MAP.get(tool_name)
     if func is None:
-        return f"Error: unknown tool '{tool_name}'"
+        return f"Error: unknown tool \'{tool_name}\'"
     try:
         return func(**tool_input)
     except Exception as exc:
@@ -296,106 +317,394 @@ def _make_serializable(obj: Any) -> Any:
     return obj
 
 
-# ---------------------------------------------------------------------------
-# Public API
-# ---------------------------------------------------------------------------
+def get_available_providers() -> list[dict[str, Any]]:
+    providers = []
+    if ANTHROPIC_API_KEY:
+        providers.append({
+            "id": "anthropic",
+            "name": "Anthropic (Claude)",
+            "models": MODEL_CONFIGS["anthropic"]["models"],
+            "default_model": MODEL_CONFIGS["anthropic"]["default_model"],
+        })
+    if OPENAI_API_KEY:
+        providers.append({
+            "id": "openai",
+            "name": "OpenAI (GPT-4)",
+            "models": MODEL_CONFIGS["openai"]["models"],
+            "default_model": MODEL_CONFIGS["openai"]["default_model"],
+        })
+    if GOOGLE_API_KEY:
+        providers.append({
+            "id": "google",
+            "name": "Google (Gemini)",
+            "models": MODEL_CONFIGS["google"]["models"],
+            "default_model": MODEL_CONFIGS["google"]["default_model"],
+        })
+    return providers
 
-def run_agent_chat(
+
+def _run_anthropic_loop(
     user_message: str,
-    history: list[dict[str, Any]] | None = None,
+    history: list[dict[str, Any]] | None,
+    model: str,
+    system_prompt: str,
+    max_iterations: int,
+    require_approval: bool,
+    tools_enabled: list[str] | None,
 ) -> dict[str, Any]:
-    """Run a single turn of the Cornerstone AI Agent.
-
-    Parameters
-    ----------
-    user_message:
-        The latest message from the user.
-    history:
-        Optional conversation history (list of ``{"role": ..., "content": ...}``).
-
-    Returns
-    -------
-    dict with keys:
-        ``response``  - the agent's text reply
-        ``tool_actions`` - list of tool calls that were executed
-        ``history``   - updated conversation history (for follow-up calls)
-    """
-    api_key = ANTHROPIC_API_KEY
-    if not api_key:
-        return {
-            "response": "The Cornerstone AI Agent is not configured. "
-                        "Please set the ANTHROPIC_API_KEY environment variable.",
-            "tool_actions": [],
-            "history": history or [],
-        }
-
-    client = anthropic.Anthropic(api_key=api_key)
-
+    client = anthropic.Anthropic(api_key=ANTHROPIC_API_KEY)
     messages: list[dict[str, Any]] = list(history) if history else []
     messages.append({"role": "user", "content": user_message})
-
     tool_actions: list[dict[str, Any]] = []
     assistant_text_parts: list[str] = []
-
+    pending_approvals: list[dict[str, Any]] = []
+    tokens_input = 0
+    tokens_output = 0
+    tool_defs = TOOL_DEFINITIONS
+    if tools_enabled:
+        tool_defs = [t for t in TOOL_DEFINITIONS if t["name"] in tools_enabled]
     try:
-        # Agent loop (max 10 iterations to prevent runaway loops)
-        for _ in range(10):
+        for _ in range(max_iterations):
             response = client.messages.create(
-                model=MODEL,
-                max_tokens=MAX_TOKENS,
-                system=SYSTEM_PROMPT,
-                tools=TOOL_DEFINITIONS,
+                model=model,
+                max_tokens=MODEL_CONFIGS["anthropic"]["max_tokens"],
+                system=system_prompt,
+                tools=tool_defs,
                 messages=messages,
             )
-
+            tokens_input += response.usage.input_tokens
+            tokens_output += response.usage.output_tokens
             serialized_content = _make_serializable(response.content)
             messages.append({"role": "assistant", "content": serialized_content})
-
-            # Collect text blocks
             for block in response.content:
                 if hasattr(block, "text"):
                     assistant_text_parts.append(block.text)
-
             if response.stop_reason == "end_turn":
                 break
-
             if response.stop_reason == "tool_use":
                 tool_results: list[dict[str, Any]] = []
                 for block in response.content:
                     if block.type != "tool_use":
                         continue
-
-                    result = _execute_tool(block.name, block.input)
-                    tool_actions.append({
-                        "tool": block.name,
-                        "input": block.input,
-                        "output": result[:2000],
-                    })
-                    tool_results.append({
-                        "type": "tool_result",
-                        "tool_use_id": block.id,
-                        "content": result,
-                    })
-
+                    if require_approval and block.name in DESTRUCTIVE_TOOLS:
+                        pending_approvals.append({
+                            "tool": block.name, "input": block.input, "tool_use_id": block.id,
+                        })
+                        tool_results.append({
+                            "type": "tool_result", "tool_use_id": block.id,
+                            "content": "[PENDING USER APPROVAL] This action requires user confirmation.",
+                        })
+                        tool_actions.append({
+                            "tool": block.name, "input": block.input,
+                            "output": "[Pending approval]", "status": "pending_approval",
+                        })
+                    else:
+                        result = _execute_tool(block.name, block.input)
+                        tool_actions.append({
+                            "tool": block.name, "input": block.input,
+                            "output": result[:2000], "status": "executed",
+                        })
+                        tool_results.append({
+                            "type": "tool_result", "tool_use_id": block.id, "content": result,
+                        })
                 messages.append({"role": "user", "content": tool_results})
+                if pending_approvals:
+                    assistant_text_parts.append(
+                        "\n\n**Approval Required:** I need your permission to execute "
+                        + str(len(pending_approvals)) + " action(s) before proceeding."
+                    )
+                    break
             else:
                 break
     except anthropic.AuthenticationError:
         return {
             "response": "Authentication failed. The ANTHROPIC_API_KEY is invalid or expired. "
                         "Please check your API key and try again.",
-            "tool_actions": tool_actions,
-            "history": history or [],
+            "tool_actions": tool_actions, "history": history or [],
+            "pending_approvals": [], "tokens_input": 0, "tokens_output": 0,
+            "provider": "anthropic", "model": model,
         }
     except anthropic.APIError as exc:
         return {
-            "response": f"An error occurred while communicating with the AI provider: {exc}",
-            "tool_actions": tool_actions,
-            "history": history or [],
+            "response": "An error occurred while communicating with the AI provider: " + str(exc),
+            "tool_actions": tool_actions, "history": history or [],
+            "pending_approvals": [], "tokens_input": 0, "tokens_output": 0,
+            "provider": "anthropic", "model": model,
         }
-
     return {
         "response": "\n\n".join(assistant_text_parts),
-        "tool_actions": tool_actions,
-        "history": messages,
+        "tool_actions": tool_actions, "history": messages,
+        "pending_approvals": pending_approvals,
+        "tokens_input": tokens_input, "tokens_output": tokens_output,
+        "provider": "anthropic", "model": model,
     }
+
+
+def _run_openai_loop(
+    user_message: str,
+    history: list[dict[str, Any]] | None,
+    model: str,
+    system_prompt: str,
+    max_iterations: int,
+    require_approval: bool,
+    tools_enabled: list[str] | None,
+) -> dict[str, Any]:
+    client = openai.OpenAI(api_key=OPENAI_API_KEY)
+    messages: list[dict[str, Any]] = [{"role": "system", "content": system_prompt}]
+    if history:
+        messages.extend(history)
+    messages.append({"role": "user", "content": user_message})
+    tool_actions: list[dict[str, Any]] = []
+    assistant_text_parts: list[str] = []
+    pending_approvals: list[dict[str, Any]] = []
+    tokens_input = 0
+    tokens_output = 0
+    tool_defs = OPENAI_TOOL_DEFINITIONS
+    if tools_enabled:
+        tool_defs = [t for t in OPENAI_TOOL_DEFINITIONS if t["function"]["name"] in tools_enabled]
+    try:
+        for _ in range(max_iterations):
+            response = client.chat.completions.create(
+                model=model,
+                max_tokens=MODEL_CONFIGS["openai"]["max_tokens"],
+                messages=messages,
+                tools=tool_defs if tool_defs else None,
+            )
+            choice = response.choices[0]
+            if response.usage:
+                tokens_input += response.usage.prompt_tokens
+                tokens_output += response.usage.completion_tokens
+            if choice.message.content:
+                assistant_text_parts.append(choice.message.content)
+            msg_dict: dict[str, Any] = {"role": "assistant", "content": choice.message.content or ""}
+            if choice.message.tool_calls:
+                msg_dict["tool_calls"] = [
+                    {"id": tc.id, "type": "function",
+                     "function": {"name": tc.function.name, "arguments": tc.function.arguments}}
+                    for tc in choice.message.tool_calls
+                ]
+            messages.append(msg_dict)
+            if choice.finish_reason == "stop":
+                break
+            if choice.finish_reason == "tool_calls" and choice.message.tool_calls:
+                for tc in choice.message.tool_calls:
+                    tool_name = tc.function.name
+                    tool_input = json.loads(tc.function.arguments)
+                    if require_approval and tool_name in DESTRUCTIVE_TOOLS:
+                        pending_approvals.append({"tool": tool_name, "input": tool_input, "tool_use_id": tc.id})
+                        messages.append({"role": "tool", "tool_call_id": tc.id, "content": "[PENDING USER APPROVAL]"})
+                        tool_actions.append({"tool": tool_name, "input": tool_input, "output": "[Pending approval]", "status": "pending_approval"})
+                    else:
+                        result = _execute_tool(tool_name, tool_input)
+                        tool_actions.append({"tool": tool_name, "input": tool_input, "output": result[:2000], "status": "executed"})
+                        messages.append({"role": "tool", "tool_call_id": tc.id, "content": result})
+                if pending_approvals:
+                    assistant_text_parts.append(
+                        "\n\n**Approval Required:** I need your permission to execute "
+                        + str(len(pending_approvals)) + " action(s) before proceeding."
+                    )
+                    break
+            else:
+                break
+    except openai.AuthenticationError:
+        return {
+            "response": "Authentication failed. The OPENAI_API_KEY is invalid or expired.",
+            "tool_actions": tool_actions, "history": [], "pending_approvals": [],
+            "tokens_input": 0, "tokens_output": 0, "provider": "openai", "model": model,
+        }
+    except openai.APIError as exc:
+        return {
+            "response": "An error occurred while communicating with OpenAI: " + str(exc),
+            "tool_actions": tool_actions, "history": [], "pending_approvals": [],
+            "tokens_input": 0, "tokens_output": 0, "provider": "openai", "model": model,
+        }
+    return {
+        "response": "\n\n".join(assistant_text_parts),
+        "tool_actions": tool_actions, "history": messages[1:],
+        "pending_approvals": pending_approvals,
+        "tokens_input": tokens_input, "tokens_output": tokens_output,
+        "provider": "openai", "model": model,
+    }
+
+
+def _run_google_loop(
+    user_message: str,
+    history: list[dict[str, Any]] | None,
+    model: str,
+    system_prompt: str,
+    max_iterations: int,
+    require_approval: bool,
+    tools_enabled: list[str] | None,
+) -> dict[str, Any]:
+    client = openai.OpenAI(
+        api_key=GOOGLE_API_KEY,
+        base_url="https://generativelanguage.googleapis.com/v1beta/openai/",
+    )
+    messages: list[dict[str, Any]] = [{"role": "system", "content": system_prompt}]
+    if history:
+        messages.extend(history)
+    messages.append({"role": "user", "content": user_message})
+    tool_actions: list[dict[str, Any]] = []
+    assistant_text_parts: list[str] = []
+    tokens_input = 0
+    tokens_output = 0
+    tool_defs = OPENAI_TOOL_DEFINITIONS
+    if tools_enabled:
+        tool_defs = [t for t in OPENAI_TOOL_DEFINITIONS if t["function"]["name"] in tools_enabled]
+    try:
+        for _ in range(max_iterations):
+            response = client.chat.completions.create(
+                model=model,
+                max_tokens=MODEL_CONFIGS["google"]["max_tokens"],
+                messages=messages,
+                tools=tool_defs if tool_defs else None,
+            )
+            choice = response.choices[0]
+            if response.usage:
+                tokens_input += response.usage.prompt_tokens
+                tokens_output += response.usage.completion_tokens
+            if choice.message.content:
+                assistant_text_parts.append(choice.message.content)
+            msg_dict: dict[str, Any] = {"role": "assistant", "content": choice.message.content or ""}
+            if choice.message.tool_calls:
+                msg_dict["tool_calls"] = [
+                    {"id": tc.id, "type": "function",
+                     "function": {"name": tc.function.name, "arguments": tc.function.arguments}}
+                    for tc in choice.message.tool_calls
+                ]
+            messages.append(msg_dict)
+            if choice.finish_reason == "stop":
+                break
+            if choice.finish_reason == "tool_calls" and choice.message.tool_calls:
+                for tc in choice.message.tool_calls:
+                    tool_name = tc.function.name
+                    tool_input = json.loads(tc.function.arguments)
+                    result = _execute_tool(tool_name, tool_input)
+                    tool_actions.append({"tool": tool_name, "input": tool_input, "output": result[:2000], "status": "executed"})
+                    messages.append({"role": "tool", "tool_call_id": tc.id, "content": result})
+            else:
+                break
+    except Exception as exc:
+        return {
+            "response": "Error communicating with Google Gemini: " + str(exc),
+            "tool_actions": tool_actions, "history": [], "pending_approvals": [],
+            "tokens_input": 0, "tokens_output": 0, "provider": "google", "model": model,
+        }
+    return {
+        "response": "\n\n".join(assistant_text_parts),
+        "tool_actions": tool_actions, "history": messages[1:],
+        "pending_approvals": [], "tokens_input": tokens_input, "tokens_output": tokens_output,
+        "provider": "google", "model": model,
+    }
+
+
+def stream_agent_chat_anthropic(
+    user_message: str,
+    history: list[dict[str, Any]] | None = None,
+    model: str | None = None,
+    system_prompt: str | None = None,
+) -> Generator[str, None, None]:
+    api_key = ANTHROPIC_API_KEY
+    if not api_key:
+        yield "data: " + json.dumps({"type": "error", "content": "ANTHROPIC_API_KEY not configured"}) + "\n\n"
+        return
+    client = anthropic.Anthropic(api_key=api_key)
+    _model = model or MODEL_CONFIGS["anthropic"]["default_model"]
+    _system = system_prompt or DEFAULT_SYSTEM_PROMPT
+    messages: list[dict[str, Any]] = list(history) if history else []
+    messages.append({"role": "user", "content": user_message})
+    tool_actions: list[dict[str, Any]] = []
+    try:
+        for iteration in range(10):
+            yield "data: " + json.dumps({"type": "iteration_start", "iteration": iteration}) + "\n\n"
+            with client.messages.stream(
+                model=_model,
+                max_tokens=MODEL_CONFIGS["anthropic"]["max_tokens"],
+                system=_system,
+                tools=TOOL_DEFINITIONS,
+                messages=messages,
+            ) as stream:
+                current_text = ""
+                for event in stream:
+                    if hasattr(event, "type"):
+                        if event.type == "content_block_delta":
+                            if hasattr(event.delta, "text"):
+                                current_text += event.delta.text
+                                yield "data: " + json.dumps({"type": "text_delta", "content": event.delta.text}) + "\n\n"
+                response = stream.get_final_message()
+            serialized_content = _make_serializable(response.content)
+            messages.append({"role": "assistant", "content": serialized_content})
+            if response.stop_reason == "end_turn":
+                break
+            if response.stop_reason == "tool_use":
+                tool_results: list[dict[str, Any]] = []
+                for block in response.content:
+                    if block.type != "tool_use":
+                        continue
+                    yield "data: " + json.dumps({"type": "tool_start", "tool": block.name, "input": block.input}) + "\n\n"
+                    result = _execute_tool(block.name, block.input)
+                    tool_actions.append({"tool": block.name, "input": block.input, "output": result[:2000], "status": "executed"})
+                    yield "data: " + json.dumps({"type": "tool_result", "tool": block.name, "output": result[:500]}) + "\n\n"
+                    tool_results.append({"type": "tool_result", "tool_use_id": block.id, "content": result})
+                messages.append({"role": "user", "content": tool_results})
+            else:
+                break
+        yield "data: " + json.dumps({"type": "done", "tool_actions": tool_actions, "history": messages}) + "\n\n"
+    except anthropic.AuthenticationError:
+        yield "data: " + json.dumps({"type": "error", "content": "Authentication failed. ANTHROPIC_API_KEY is invalid."}) + "\n\n"
+    except anthropic.APIError as exc:
+        yield "data: " + json.dumps({"type": "error", "content": "API error: " + str(exc)}) + "\n\n"
+
+
+def run_agent_chat(
+    user_message: str,
+    history: list[dict[str, Any]] | None = None,
+    provider: str = "anthropic",
+    model: str | None = None,
+    system_prompt: str | None = None,
+    max_iterations: int = 10,
+    require_approval: bool = False,
+    tools_enabled: list[str] | None = None,
+) -> dict[str, Any]:
+    start_time = time.time()
+    _system = system_prompt or DEFAULT_SYSTEM_PROMPT
+    if provider == "anthropic":
+        if not ANTHROPIC_API_KEY:
+            return _unconfigured_response("ANTHROPIC_API_KEY", history)
+        _model = model or MODEL_CONFIGS["anthropic"]["default_model"]
+        result = _run_anthropic_loop(user_message, history, _model, _system, max_iterations, require_approval, tools_enabled)
+    elif provider == "openai":
+        if not OPENAI_API_KEY:
+            return _unconfigured_response("OPENAI_API_KEY", history)
+        _model = model or MODEL_CONFIGS["openai"]["default_model"]
+        result = _run_openai_loop(user_message, history, _model, _system, max_iterations, require_approval, tools_enabled)
+    elif provider == "google":
+        if not GOOGLE_API_KEY:
+            return _unconfigured_response("GOOGLE_API_KEY", history)
+        _model = model or MODEL_CONFIGS["google"]["default_model"]
+        result = _run_google_loop(user_message, history, _model, _system, max_iterations, require_approval, tools_enabled)
+    else:
+        return {
+            "response": "Unknown provider: " + provider + ". Supported: anthropic, openai, google.",
+            "tool_actions": [], "history": history or [], "pending_approvals": [],
+            "tokens_input": 0, "tokens_output": 0, "provider": provider, "model": "",
+        }
+    result["latency_ms"] = int((time.time() - start_time) * 1000)
+    result["session_id"] = str(uuid.uuid4())
+    return result
+
+
+def _unconfigured_response(key_name: str, history: list[dict[str, Any]] | None) -> dict[str, Any]:
+    return {
+        "response": "The Cornerstone AI Agent is not configured. Please set the " + key_name + " environment variable.",
+        "tool_actions": [], "history": history or [], "pending_approvals": [],
+        "tokens_input": 0, "tokens_output": 0, "provider": "", "model": "",
+    }
+
+
+def execute_approved_tools(approvals: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    results = []
+    for approval in approvals:
+        result = _execute_tool(approval["tool"], approval["input"])
+        results.append({"tool": approval["tool"], "input": approval["input"], "output": result[:2000], "status": "executed"})
+    return results

--- a/backend/app/services/agent_service.py
+++ b/backend/app/services/agent_service.py
@@ -337,48 +337,62 @@ def run_agent_chat(
     tool_actions: list[dict[str, Any]] = []
     assistant_text_parts: list[str] = []
 
-    # Agent loop (max 10 iterations to prevent runaway loops)
-    for _ in range(10):
-        response = client.messages.create(
-            model=MODEL,
-            max_tokens=MAX_TOKENS,
-            system=SYSTEM_PROMPT,
-            tools=TOOL_DEFINITIONS,
-            messages=messages,
-        )
+    try:
+        # Agent loop (max 10 iterations to prevent runaway loops)
+        for _ in range(10):
+            response = client.messages.create(
+                model=MODEL,
+                max_tokens=MAX_TOKENS,
+                system=SYSTEM_PROMPT,
+                tools=TOOL_DEFINITIONS,
+                messages=messages,
+            )
 
-        serialized_content = _make_serializable(response.content)
-        messages.append({"role": "assistant", "content": serialized_content})
+            serialized_content = _make_serializable(response.content)
+            messages.append({"role": "assistant", "content": serialized_content})
 
-        # Collect text blocks
-        for block in response.content:
-            if hasattr(block, "text"):
-                assistant_text_parts.append(block.text)
-
-        if response.stop_reason == "end_turn":
-            break
-
-        if response.stop_reason == "tool_use":
-            tool_results: list[dict[str, Any]] = []
+            # Collect text blocks
             for block in response.content:
-                if block.type != "tool_use":
-                    continue
+                if hasattr(block, "text"):
+                    assistant_text_parts.append(block.text)
 
-                result = _execute_tool(block.name, block.input)
-                tool_actions.append({
-                    "tool": block.name,
-                    "input": block.input,
-                    "output": result[:2000],
-                })
-                tool_results.append({
-                    "type": "tool_result",
-                    "tool_use_id": block.id,
-                    "content": result,
-                })
+            if response.stop_reason == "end_turn":
+                break
 
-            messages.append({"role": "user", "content": tool_results})
-        else:
-            break
+            if response.stop_reason == "tool_use":
+                tool_results: list[dict[str, Any]] = []
+                for block in response.content:
+                    if block.type != "tool_use":
+                        continue
+
+                    result = _execute_tool(block.name, block.input)
+                    tool_actions.append({
+                        "tool": block.name,
+                        "input": block.input,
+                        "output": result[:2000],
+                    })
+                    tool_results.append({
+                        "type": "tool_result",
+                        "tool_use_id": block.id,
+                        "content": result,
+                    })
+
+                messages.append({"role": "user", "content": tool_results})
+            else:
+                break
+    except anthropic.AuthenticationError:
+        return {
+            "response": "Authentication failed. The ANTHROPIC_API_KEY is invalid or expired. "
+                        "Please check your API key and try again.",
+            "tool_actions": tool_actions,
+            "history": history or [],
+        }
+    except anthropic.APIError as exc:
+        return {
+            "response": f"An error occurred while communicating with the AI provider: {exc}",
+            "tool_actions": tool_actions,
+            "history": history or [],
+        }
 
     return {
         "response": "\n\n".join(assistant_text_parts),

--- a/backend/app/services/agent_service.py
+++ b/backend/app/services/agent_service.py
@@ -8,7 +8,6 @@ were executed.
 
 from __future__ import annotations
 
-import json
 import os
 import subprocess
 from typing import Any
@@ -67,8 +66,16 @@ def _is_blocked(command: str) -> bool:
 # Tool implementations (sandboxed to WORKSPACE)
 # ---------------------------------------------------------------------------
 
+def _resolve_safe(path: str) -> str:
+    """Resolve *path* relative to WORKSPACE and verify it stays inside."""
+    resolved = os.path.realpath(os.path.join(WORKSPACE, path))
+    if not resolved.startswith(os.path.realpath(WORKSPACE) + os.sep) and resolved != os.path.realpath(WORKSPACE):
+        raise PermissionError(f"Path escapes workspace: {path}")
+    return resolved
+
+
 def _write_file(filepath: str, content: str) -> str:
-    full = os.path.join(WORKSPACE, filepath)
+    full = _resolve_safe(filepath)
     os.makedirs(os.path.dirname(full), exist_ok=True)
     with open(full, "w", encoding="utf-8") as fh:
         fh.write(content)
@@ -76,7 +83,7 @@ def _write_file(filepath: str, content: str) -> str:
 
 
 def _read_file(filepath: str) -> str:
-    full = os.path.join(WORKSPACE, filepath)
+    full = _resolve_safe(filepath)
     if not os.path.isfile(full):
         return f"Error: file not found \u2014 {filepath}"
     with open(full, "r", encoding="utf-8") as fh:
@@ -84,7 +91,7 @@ def _read_file(filepath: str) -> str:
 
 
 def _list_files(directory: str = ".") -> str:
-    full = os.path.join(WORKSPACE, directory)
+    full = _resolve_safe(directory)
     if not os.path.isdir(full):
         return f"Error: directory not found \u2014 {directory}"
     files: list[str] = []
@@ -112,7 +119,7 @@ def _run_command(command: str) -> str:
 
 
 def _delete_file(filepath: str) -> str:
-    full = os.path.join(WORKSPACE, filepath)
+    full = _resolve_safe(filepath)
     if not os.path.isfile(full):
         return f"Error: file not found \u2014 {filepath}"
     os.remove(full)
@@ -120,13 +127,13 @@ def _delete_file(filepath: str) -> str:
 
 
 def _create_directory(directory: str) -> str:
-    full = os.path.join(WORKSPACE, directory)
+    full = _resolve_safe(directory)
     os.makedirs(full, exist_ok=True)
     return f"Successfully created directory {directory}"
 
 
 def _search_in_files(pattern: str, directory: str = ".") -> str:
-    full = os.path.join(WORKSPACE, directory)
+    full = _resolve_safe(directory)
     if not os.path.isdir(full):
         return f"Error: directory not found \u2014 {directory}"
     matches: list[str] = []

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,4 +10,5 @@ httpx~=0.28.1
 python-multipart~=0.0.22
 alembic~=1.16.1
 openai~=1.82.0
+anthropic~=0.40.0
 pytest~=8.3.5

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,6 +7,9 @@ import AIEngines from "./pages/AIEngines.jsx";
 import FundingTracker from "./pages/FundingTracker.jsx";
 import Rewards from "./pages/Rewards.jsx";
 import CornerstoneAgent from "./pages/CornerstoneAgent.jsx";
+import AnalyticsDashboard from "./pages/AnalyticsDashboard.jsx";
+import AgentMarketplace from "./pages/AgentMarketplace.jsx";
+import SettingsPage from "./pages/SettingsPage.jsx";
 import AppSidebar from "./components/Sidebar.jsx";
 
 function PrivateRoute({ children }) {
@@ -62,6 +65,9 @@ export default function App() {
           <Route path="/funding" element={<FundingTracker />} />
           <Route path="/rewards" element={<Rewards />} />
           <Route path="/agent" element={<CornerstoneAgent />} />
+          <Route path="/analytics" element={<AnalyticsDashboard />} />
+          <Route path="/marketplace" element={<AgentMarketplace />} />
+          <Route path="/settings" element={<SettingsPage />} />
           <Route path="*" element={<Navigate to="/ideas" replace />} />
         </Routes>
       </AuthenticatedLayout>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,6 +6,7 @@ import BusinessIdeas from "./pages/BusinessIdeas.jsx";
 import AIEngines from "./pages/AIEngines.jsx";
 import FundingTracker from "./pages/FundingTracker.jsx";
 import Rewards from "./pages/Rewards.jsx";
+import CornerstoneAgent from "./pages/CornerstoneAgent.jsx";
 import AppSidebar from "./components/Sidebar.jsx";
 
 function PrivateRoute({ children }) {
@@ -60,6 +61,7 @@ export default function App() {
           <Route path="/ai-engines" element={<AIEngines />} />
           <Route path="/funding" element={<FundingTracker />} />
           <Route path="/rewards" element={<Rewards />} />
+          <Route path="/agent" element={<CornerstoneAgent />} />
           <Route path="*" element={<Navigate to="/ideas" replace />} />
         </Routes>
       </AuthenticatedLayout>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import { BusinessIdeasPage } from './pages/BusinessIdeasPage';
 import { AIEnginesPage } from './pages/AIEnginesPage';
 import { FundingTrackerPage } from './pages/FundingTrackerPage';
 import { RewardsPage } from './pages/RewardsPage';
+import { CornerstoneAgentPage } from './pages/CornerstoneAgentPage';
 import { Sidebar } from './components/Sidebar';
 
 function App() {
@@ -30,6 +31,7 @@ function App() {
             <Route path="/ai-engines" element={<AIEnginesPage />} />
             <Route path="/funding" element={<FundingTrackerPage />} />
             <Route path="/rewards" element={<RewardsPage />} />
+            <Route path="/agent" element={<CornerstoneAgentPage />} />
           </Routes>
         </main>
       </div>

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -7,6 +7,7 @@ const navItems = [
   { to: "/ai-engines", label: "AI Engines" },
   { to: "/funding", label: "Funding Tracker" },
   { to: "/rewards", label: "Rewards" },
+  { to: "/agent", label: "Cornerstone Agent" },
 ];
 
 const linkStyle = {

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -8,6 +8,9 @@ const navItems = [
   { to: "/funding", label: "Funding Tracker" },
   { to: "/rewards", label: "Rewards" },
   { to: "/agent", label: "Cornerstone Agent" },
+  { to: "/analytics", label: "Analytics" },
+  { to: "/marketplace", label: "Agent Marketplace" },
+  { to: "/settings", label: "Settings" },
 ];
 
 const linkStyle = {

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -12,6 +12,7 @@ const navItems = [
   { to: '/ai-engines', label: 'AI Engines' },
   { to: '/funding', label: 'Funding Tracker' },
   { to: '/rewards', label: 'Rewards' },
+  { to: '/agent', label: 'Cornerstone Agent' },
 ];
 
 const linkStyle: React.CSSProperties = {

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -165,4 +165,10 @@ export const api = {
     request("GET", `/rewards/leaderboard?limit=${limit}`),
 
   getRevenueModels: () => request("GET", "/rewards/revenue-models"),
+
+  /** Cornerstone AI Agent */
+  sendAgentMessage: (message, history) =>
+    request("POST", "/agent/chat", { message, history }),
+
+  getAgentInfo: () => request("GET", "/agent/info"),
 };

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -167,8 +167,61 @@ export const api = {
   getRevenueModels: () => request("GET", "/rewards/revenue-models"),
 
   /** Cornerstone AI Agent */
-  sendAgentMessage: (message, history) =>
-    request("POST", "/agent/chat", { message, history }),
+  sendAgentMessage: (message, history, provider, model, requireApproval, agentConfigId) =>
+    request("POST", "/agent/chat", {
+      message,
+      history,
+      provider: provider || "anthropic",
+      model: model || null,
+      require_approval: requireApproval || false,
+      agent_config_id: agentConfigId || null,
+    }),
+
+  streamAgentMessage: (message, history, model) => {
+    const token = localStorage.getItem("access_token");
+    return fetch(`${BASE_URL}/agent/chat/stream`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+      body: JSON.stringify({ message, history, model }),
+    });
+  },
+
+  approveTools: (approvals, approved) =>
+    request("POST", "/agent/approve", { approvals, approved }),
 
   getAgentInfo: () => request("GET", "/agent/info"),
+
+  /** Agent Audit Logs */
+  getAuditLogs: (limit = 50, offset = 0) =>
+    request("GET", `/agent/audit?limit=${limit}&offset=${offset}`),
+
+  /** Agent Analytics */
+  getAgentAnalytics: () => request("GET", "/agent/analytics"),
+
+  /** Agent Marketplace */
+  getMarketplaceConfigs: (category) => {
+    const qs = category ? `?category=${category}` : "";
+    return request("GET", `/agent/marketplace${qs}`);
+  },
+
+  createMarketplaceConfig: (payload) =>
+    request("POST", "/agent/marketplace", payload),
+
+  deleteMarketplaceConfig: (id) =>
+    request("DELETE", `/agent/marketplace/${id}`),
+
+  /** Subscription / Usage */
+  getSubscription: () => request("GET", "/agent/subscription"),
+
+  upgradeSubscription: () =>
+    request("POST", "/agent/subscription/upgrade"),
+
+  /** Platform Settings (White-Label) */
+  getPlatformSettings: () => request("GET", "/agent/settings"),
+
+  updatePlatformSettings: (payload) =>
+    request("PUT", "/agent/settings", payload),
 };

--- a/frontend/src/pages/AgentMarketplace.jsx
+++ b/frontend/src/pages/AgentMarketplace.jsx
@@ -1,0 +1,140 @@
+import { useEffect, useState } from "react";
+import { api } from "../lib/api.js";
+
+const cardStyle = { background: "#fff", borderRadius: 10, boxShadow: "0 2px 12px rgba(0,0,0,0.06)", padding: "20px 24px" };
+const btnPrimary = { background: "#3182ce", color: "#fff", border: "none", padding: "8px 20px", borderRadius: 6, cursor: "pointer", fontWeight: 600, fontSize: 13 };
+const btnSecondary = { background: "transparent", border: "1px solid #e2e8f0", color: "#718096", padding: "8px 16px", borderRadius: 6, cursor: "pointer", fontSize: 13, fontWeight: 500 };
+const inputStyle = { width: "100%", padding: "10px 14px", border: "1px solid #e2e8f0", borderRadius: 8, fontSize: 14, outline: "none", boxSizing: "border-box" };
+const textareaStyle = { ...inputStyle, minHeight: 80, resize: "vertical", fontFamily: "inherit" };
+const selectStyle = { padding: "8px 12px", border: "1px solid #e2e8f0", borderRadius: 6, fontSize: 13, background: "#fff", outline: "none" };
+const CATEGORIES = ["general", "coding", "writing", "research", "devops", "data", "other"];
+
+export default function AgentMarketplace() {
+  const [configs, setConfigs] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [showCreate, setShowCreate] = useState(false);
+  const [filterCat, setFilterCat] = useState("");
+  const [form, setForm] = useState({ name: "", description: "", system_prompt: "", model_provider: "anthropic", model_name: "", tools_enabled: [], category: "general", is_public: true });
+
+  const loadConfigs = () => {
+    api.getMarketplaceConfigs(filterCat || undefined).then((data) => { setConfigs(Array.isArray(data) ? data : data?.configs || []); setLoading(false); }).catch(() => setLoading(false));
+  };
+
+  useEffect(() => { loadConfigs(); }, [filterCat]);
+
+  const handleCreate = async (e) => {
+    e.preventDefault();
+    try {
+      await api.createMarketplaceConfig(form);
+      setShowCreate(false);
+      setForm({ name: "", description: "", system_prompt: "", model_provider: "anthropic", model_name: "", tools_enabled: [], category: "general", is_public: true });
+      loadConfigs();
+    } catch (err) { alert(err.message || "Error creating config"); }
+  };
+
+  const handleDelete = async (id) => {
+    if (!confirm("Delete this agent config?")) return;
+    try { await api.deleteMarketplaceConfig(id); loadConfigs(); } catch (err) { alert(err.message); }
+  };
+
+  if (loading) return <div style={{ padding: 32, textAlign: "center", color: "#718096" }}>Loading marketplace...</div>;
+
+  return (
+    <div style={{ maxWidth: 960, margin: "0 auto", padding: 16 }}>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 20 }}>
+        <div>
+          <h2 style={{ margin: 0, color: "#2d3748", fontSize: 22 }}>Agent Marketplace</h2>
+          <p style={{ margin: "4px 0 0", color: "#718096", fontSize: 13 }}>Browse and create custom agent configurations</p>
+        </div>
+        <button onClick={() => setShowCreate(!showCreate)} style={btnPrimary}>{showCreate ? "Cancel" : "Create Agent"}</button>
+      </div>
+
+      {/* Create form */}
+      {showCreate && (
+        <form onSubmit={handleCreate} style={{ ...cardStyle, marginBottom: 24 }}>
+          <h3 style={{ margin: "0 0 16px", color: "#2d3748", fontSize: 16 }}>Create Custom Agent</h3>
+          <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+            <div>
+              <label style={{ fontSize: 12, color: "#718096", fontWeight: 600, display: "block", marginBottom: 4 }}>Name</label>
+              <input value={form.name} onChange={(e) => setForm({ ...form, name: e.target.value })} placeholder="My Custom Agent" required style={inputStyle} />
+            </div>
+            <div>
+              <label style={{ fontSize: 12, color: "#718096", fontWeight: 600, display: "block", marginBottom: 4 }}>Description</label>
+              <input value={form.description} onChange={(e) => setForm({ ...form, description: e.target.value })} placeholder="What does this agent do?" style={inputStyle} />
+            </div>
+            <div>
+              <label style={{ fontSize: 12, color: "#718096", fontWeight: 600, display: "block", marginBottom: 4 }}>System Prompt</label>
+              <textarea value={form.system_prompt} onChange={(e) => setForm({ ...form, system_prompt: e.target.value })} placeholder="You are a helpful assistant specialized in..." required style={textareaStyle} />
+            </div>
+            <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
+              <div style={{ flex: 1, minWidth: 140 }}>
+                <label style={{ fontSize: 12, color: "#718096", fontWeight: 600, display: "block", marginBottom: 4 }}>Provider</label>
+                <select value={form.model_provider} onChange={(e) => setForm({ ...form, model_provider: e.target.value })} style={{ ...selectStyle, width: "100%" }}>
+                  <option value="anthropic">Anthropic</option>
+                  <option value="openai">OpenAI</option>
+                  <option value="google">Google</option>
+                </select>
+              </div>
+              <div style={{ flex: 1, minWidth: 140 }}>
+                <label style={{ fontSize: 12, color: "#718096", fontWeight: 600, display: "block", marginBottom: 4 }}>Category</label>
+                <select value={form.category} onChange={(e) => setForm({ ...form, category: e.target.value })} style={{ ...selectStyle, width: "100%" }}>
+                  {CATEGORIES.map((c) => <option key={c} value={c}>{c.charAt(0).toUpperCase() + c.slice(1)}</option>)}
+                </select>
+              </div>
+              <div style={{ display: "flex", alignItems: "flex-end" }}>
+                <label style={{ display: "flex", alignItems: "center", gap: 4, fontSize: 12, color: "#718096", cursor: "pointer" }}>
+                  <input type="checkbox" checked={form.is_public} onChange={(e) => setForm({ ...form, is_public: e.target.checked })} /> Public
+                </label>
+              </div>
+            </div>
+            <button type="submit" style={btnPrimary}>Create Agent Config</button>
+          </div>
+        </form>
+      )}
+
+      {/* Filter */}
+      <div style={{ display: "flex", gap: 8, marginBottom: 20, flexWrap: "wrap" }}>
+        <button onClick={() => setFilterCat("")} style={filterCat === "" ? { ...btnPrimary, padding: "6px 14px", fontSize: 12 } : { ...btnSecondary, padding: "6px 14px", fontSize: 12 }}>All</button>
+        {CATEGORIES.map((c) => (
+          <button key={c} onClick={() => setFilterCat(c)} style={filterCat === c ? { ...btnPrimary, padding: "6px 14px", fontSize: 12 } : { ...btnSecondary, padding: "6px 14px", fontSize: 12 }}>
+            {c.charAt(0).toUpperCase() + c.slice(1)}
+          </button>
+        ))}
+      </div>
+
+      {/* Agent cards */}
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(280px, 1fr))", gap: 16 }}>
+        {configs.map((config) => (
+          <div key={config.id} style={cardStyle}>
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", marginBottom: 8 }}>
+              <div style={{ fontSize: 28 }}>{config.icon || "🤖"}</div>
+              <span style={{ background: "#ebf4ff", color: "#3182ce", padding: "2px 8px", borderRadius: 8, fontSize: 10, fontWeight: 600 }}>{config.category || "general"}</span>
+            </div>
+            <h3 style={{ margin: "0 0 4px", color: "#2d3748", fontSize: 16 }}>{config.name}</h3>
+            <p style={{ margin: "0 0 8px", color: "#718096", fontSize: 12, lineHeight: 1.5 }}>{config.description || "No description"}</p>
+            <div style={{ display: "flex", gap: 8, flexWrap: "wrap", marginBottom: 8 }}>
+              <span style={{ background: "#f7fafc", color: "#4a5568", padding: "2px 8px", borderRadius: 6, fontSize: 10, fontWeight: 600 }}>{config.model_provider}</span>
+              {config.model_name && <span style={{ background: "#f7fafc", color: "#4a5568", padding: "2px 8px", borderRadius: 6, fontSize: 10 }}>{config.model_name}</span>}
+            </div>
+            <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", borderTop: "1px solid #edf2f7", paddingTop: 8 }}>
+              <span style={{ fontSize: 11, color: "#a0aec0" }}>{config.use_count || 0} uses</span>
+              <div style={{ display: "flex", gap: 8 }}>
+                <button onClick={() => { window.location.href = "/agent"; }} style={{ ...btnPrimary, padding: "4px 12px", fontSize: 11 }}>Use</button>
+                <button onClick={() => handleDelete(config.id)} style={{ ...btnSecondary, padding: "4px 12px", fontSize: 11, color: "#e53e3e", borderColor: "#fed7d7" }}>Delete</button>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {configs.length === 0 && (
+        <div style={{ ...cardStyle, textAlign: "center", padding: 48 }}>
+          <div style={{ fontSize: 40, marginBottom: 16 }}>🤖</div>
+          <h3 style={{ margin: "0 0 8px", color: "#2d3748" }}>No Agent Configs Yet</h3>
+          <p style={{ margin: "0 0 16px", color: "#718096", fontSize: 14 }}>Create your first custom agent configuration to get started.</p>
+          <button onClick={() => setShowCreate(true)} style={btnPrimary}>Create Agent</button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/AnalyticsDashboard.jsx
+++ b/frontend/src/pages/AnalyticsDashboard.jsx
@@ -25,8 +25,13 @@ export default function AnalyticsDashboard() {
 
   if (loading) return <div style={{ padding: 32, textAlign: "center", color: "#718096" }}>Loading analytics...</div>;
 
-  const stats = analytics || { total_messages: 0, total_tokens: 0, avg_latency_ms: 0, messages_today: 0, tool_usage: {}, model_usage: {}, daily_messages: [] };
-  const maxDaily = Math.max(1, ...((stats.daily_messages || []).map((d) => d.count)));
+  const stats = analytics || { total_messages: 0, total_tokens: 0, avg_latency_ms: 0, messages_today: 0, tool_usage: {}, model_usage: {}, daily_messages: [], messages_by_day: [], top_tools: [], messages_by_provider: {} };
+  // Support both field name conventions
+  const dailyMessages = stats.daily_messages || stats.messages_by_day || [];
+  const toolUsage = stats.tool_usage || (stats.top_tools ? Object.fromEntries((stats.top_tools || []).map(t => [t.tool, t.count])) : {});
+  const modelUsage = stats.model_usage || stats.messages_by_provider || {};
+  const messagesToday = stats.messages_today ?? stats.total_messages ?? 0;
+  const maxDaily = Math.max(1, ...(dailyMessages.map((d) => d.count)));
 
   return (
     <div style={{ maxWidth: 960, margin: "0 auto", padding: 16 }}>
@@ -40,7 +45,7 @@ export default function AnalyticsDashboard() {
           <p style={statLabel}>Total Messages</p>
         </div>
         <div style={{ ...cardStyle, ...statStyle }}>
-          <p style={statValue}>{stats.messages_today}</p>
+          <p style={statValue}>{messagesToday}</p>
           <p style={statLabel}>Messages Today</p>
         </div>
         <div style={{ ...cardStyle, ...statStyle }}>
@@ -57,13 +62,13 @@ export default function AnalyticsDashboard() {
       <div style={{ ...cardStyle, marginBottom: 24 }}>
         <h3 style={{ margin: "0 0 16px", color: "#2d3748", fontSize: 16 }}>Messages per Day</h3>
         <div style={{ display: "flex", gap: 4, alignItems: "flex-end", height: 120 }}>
-          {(stats.daily_messages || []).map((d, i) => (
+          {dailyMessages.map((d, i) => (
             <div key={i} style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center" }}>
               <div style={{ width: "100%", maxWidth: 40, background: "#3182ce", borderRadius: "4px 4px 0 0", height: Math.max(4, (d.count / maxDaily) * 100) }} />
               <span style={{ fontSize: 9, color: "#a0aec0", marginTop: 4 }}>{d.date?.slice(5) || ""}</span>
             </div>
           ))}
-          {(!stats.daily_messages || stats.daily_messages.length === 0) && <p style={{ color: "#a0aec0", fontSize: 13, margin: "auto" }}>No data yet</p>}
+          {dailyMessages.length === 0 && <p style={{ color: "#a0aec0", fontSize: 13, margin: "auto" }}>No data yet</p>}
         </div>
       </div>
 
@@ -71,8 +76,8 @@ export default function AnalyticsDashboard() {
         {/* Tool usage */}
         <div style={{ ...cardStyle, flex: 1, minWidth: 280 }}>
           <h3 style={{ margin: "0 0 16px", color: "#2d3748", fontSize: 16 }}>Tool Usage</h3>
-          {Object.entries(stats.tool_usage || {}).sort((a, b) => b[1] - a[1]).map(([tool, count]) => {
-            const max = Math.max(1, ...Object.values(stats.tool_usage || {}));
+          {Object.entries(toolUsage).sort((a, b) => b[1] - a[1]).map(([tool, count]) => {
+            const max = Math.max(1, ...Object.values(toolUsage));
             return (
               <div key={tool} style={{ marginBottom: 8 }}>
                 <div style={{ display: "flex", justifyContent: "space-between", fontSize: 12, marginBottom: 2 }}>
@@ -83,14 +88,14 @@ export default function AnalyticsDashboard() {
               </div>
             );
           })}
-          {Object.keys(stats.tool_usage || {}).length === 0 && <p style={{ color: "#a0aec0", fontSize: 13 }}>No tool usage data</p>}
+          {Object.keys(toolUsage).length === 0 && <p style={{ color: "#a0aec0", fontSize: 13 }}>No tool usage data</p>}
         </div>
 
         {/* Model usage */}
         <div style={{ ...cardStyle, flex: 1, minWidth: 280 }}>
           <h3 style={{ margin: "0 0 16px", color: "#2d3748", fontSize: 16 }}>Model Usage</h3>
-          {Object.entries(stats.model_usage || {}).sort((a, b) => b[1] - a[1]).map(([mdl, count]) => {
-            const max = Math.max(1, ...Object.values(stats.model_usage || {}));
+          {Object.entries(modelUsage).sort((a, b) => b[1] - a[1]).map(([mdl, count]) => {
+            const max = Math.max(1, ...Object.values(modelUsage));
             return (
               <div key={mdl} style={{ marginBottom: 8 }}>
                 <div style={{ display: "flex", justifyContent: "space-between", fontSize: 12, marginBottom: 2 }}>
@@ -101,7 +106,7 @@ export default function AnalyticsDashboard() {
               </div>
             );
           })}
-          {Object.keys(stats.model_usage || {}).length === 0 && <p style={{ color: "#a0aec0", fontSize: 13 }}>No model usage data</p>}
+          {Object.keys(modelUsage).length === 0 && <p style={{ color: "#a0aec0", fontSize: 13 }}>No model usage data</p>}
         </div>
       </div>
 

--- a/frontend/src/pages/AnalyticsDashboard.jsx
+++ b/frontend/src/pages/AnalyticsDashboard.jsx
@@ -1,0 +1,143 @@
+import { useEffect, useState } from "react";
+import { api } from "../lib/api.js";
+
+const cardStyle = { background: "#fff", borderRadius: 10, boxShadow: "0 2px 12px rgba(0,0,0,0.06)", padding: "20px 24px" };
+const statStyle = { textAlign: "center", flex: 1, minWidth: 140 };
+const statValue = { fontSize: 28, fontWeight: 700, color: "#2d3748", margin: 0 };
+const statLabel = { fontSize: 12, color: "#718096", marginTop: 4 };
+const barBg = { height: 24, background: "#edf2f7", borderRadius: 6, overflow: "hidden", marginBottom: 4 };
+
+export default function AnalyticsDashboard() {
+  const [analytics, setAnalytics] = useState(null);
+  const [logs, setLogs] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    Promise.all([
+      api.getAgentAnalytics().catch(() => null),
+      api.getAuditLogs(20, 0).catch(() => []),
+    ]).then(([a, l]) => {
+      setAnalytics(a);
+      setLogs(Array.isArray(l) ? l : l?.logs || []);
+      setLoading(false);
+    });
+  }, []);
+
+  if (loading) return <div style={{ padding: 32, textAlign: "center", color: "#718096" }}>Loading analytics...</div>;
+
+  const stats = analytics || { total_messages: 0, total_tokens: 0, avg_latency_ms: 0, messages_today: 0, tool_usage: {}, model_usage: {}, daily_messages: [] };
+  const maxDaily = Math.max(1, ...((stats.daily_messages || []).map((d) => d.count)));
+
+  return (
+    <div style={{ maxWidth: 960, margin: "0 auto", padding: 16 }}>
+      <h2 style={{ margin: "0 0 4px", color: "#2d3748", fontSize: 22 }}>Analytics Dashboard</h2>
+      <p style={{ margin: "0 0 20px", color: "#718096", fontSize: 13 }}>Agent usage metrics and audit trail</p>
+
+      {/* Summary cards */}
+      <div style={{ display: "flex", gap: 16, flexWrap: "wrap", marginBottom: 24 }}>
+        <div style={{ ...cardStyle, ...statStyle }}>
+          <p style={statValue}>{stats.total_messages}</p>
+          <p style={statLabel}>Total Messages</p>
+        </div>
+        <div style={{ ...cardStyle, ...statStyle }}>
+          <p style={statValue}>{stats.messages_today}</p>
+          <p style={statLabel}>Messages Today</p>
+        </div>
+        <div style={{ ...cardStyle, ...statStyle }}>
+          <p style={statValue}>{(stats.total_tokens || 0).toLocaleString()}</p>
+          <p style={statLabel}>Total Tokens</p>
+        </div>
+        <div style={{ ...cardStyle, ...statStyle }}>
+          <p style={statValue}>{Math.round(stats.avg_latency_ms || 0)}ms</p>
+          <p style={statLabel}>Avg Latency</p>
+        </div>
+      </div>
+
+      {/* Daily messages chart */}
+      <div style={{ ...cardStyle, marginBottom: 24 }}>
+        <h3 style={{ margin: "0 0 16px", color: "#2d3748", fontSize: 16 }}>Messages per Day</h3>
+        <div style={{ display: "flex", gap: 4, alignItems: "flex-end", height: 120 }}>
+          {(stats.daily_messages || []).map((d, i) => (
+            <div key={i} style={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "center" }}>
+              <div style={{ width: "100%", maxWidth: 40, background: "#3182ce", borderRadius: "4px 4px 0 0", height: Math.max(4, (d.count / maxDaily) * 100) }} />
+              <span style={{ fontSize: 9, color: "#a0aec0", marginTop: 4 }}>{d.date?.slice(5) || ""}</span>
+            </div>
+          ))}
+          {(!stats.daily_messages || stats.daily_messages.length === 0) && <p style={{ color: "#a0aec0", fontSize: 13, margin: "auto" }}>No data yet</p>}
+        </div>
+      </div>
+
+      <div style={{ display: "flex", gap: 16, flexWrap: "wrap", marginBottom: 24 }}>
+        {/* Tool usage */}
+        <div style={{ ...cardStyle, flex: 1, minWidth: 280 }}>
+          <h3 style={{ margin: "0 0 16px", color: "#2d3748", fontSize: 16 }}>Tool Usage</h3>
+          {Object.entries(stats.tool_usage || {}).sort((a, b) => b[1] - a[1]).map(([tool, count]) => {
+            const max = Math.max(1, ...Object.values(stats.tool_usage || {}));
+            return (
+              <div key={tool} style={{ marginBottom: 8 }}>
+                <div style={{ display: "flex", justifyContent: "space-between", fontSize: 12, marginBottom: 2 }}>
+                  <span style={{ color: "#4a5568", fontWeight: 600 }}>{tool}</span>
+                  <span style={{ color: "#718096" }}>{count}</span>
+                </div>
+                <div style={barBg}><div style={{ height: "100%", width: (count / max * 100) + "%", background: "#805ad5", borderRadius: 6 }} /></div>
+              </div>
+            );
+          })}
+          {Object.keys(stats.tool_usage || {}).length === 0 && <p style={{ color: "#a0aec0", fontSize: 13 }}>No tool usage data</p>}
+        </div>
+
+        {/* Model usage */}
+        <div style={{ ...cardStyle, flex: 1, minWidth: 280 }}>
+          <h3 style={{ margin: "0 0 16px", color: "#2d3748", fontSize: 16 }}>Model Usage</h3>
+          {Object.entries(stats.model_usage || {}).sort((a, b) => b[1] - a[1]).map(([mdl, count]) => {
+            const max = Math.max(1, ...Object.values(stats.model_usage || {}));
+            return (
+              <div key={mdl} style={{ marginBottom: 8 }}>
+                <div style={{ display: "flex", justifyContent: "space-between", fontSize: 12, marginBottom: 2 }}>
+                  <span style={{ color: "#4a5568", fontWeight: 600 }}>{mdl}</span>
+                  <span style={{ color: "#718096" }}>{count}</span>
+                </div>
+                <div style={barBg}><div style={{ height: "100%", width: (count / max * 100) + "%", background: "#3182ce", borderRadius: 6 }} /></div>
+              </div>
+            );
+          })}
+          {Object.keys(stats.model_usage || {}).length === 0 && <p style={{ color: "#a0aec0", fontSize: 13 }}>No model usage data</p>}
+        </div>
+      </div>
+
+      {/* Recent audit logs */}
+      <div style={cardStyle}>
+        <h3 style={{ margin: "0 0 16px", color: "#2d3748", fontSize: 16 }}>Recent Audit Logs</h3>
+        <div style={{ overflowX: "auto" }}>
+          <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 12 }}>
+            <thead>
+              <tr style={{ borderBottom: "2px solid #e2e8f0" }}>
+                <th style={{ textAlign: "left", padding: "8px 12px", color: "#718096", fontWeight: 600 }}>Time</th>
+                <th style={{ textAlign: "left", padding: "8px 12px", color: "#718096", fontWeight: 600 }}>Message</th>
+                <th style={{ textAlign: "left", padding: "8px 12px", color: "#718096", fontWeight: 600 }}>Model</th>
+                <th style={{ textAlign: "left", padding: "8px 12px", color: "#718096", fontWeight: 600 }}>Tokens</th>
+                <th style={{ textAlign: "left", padding: "8px 12px", color: "#718096", fontWeight: 600 }}>Latency</th>
+                <th style={{ textAlign: "left", padding: "8px 12px", color: "#718096", fontWeight: 600 }}>Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {logs.map((log, i) => (
+                <tr key={i} style={{ borderBottom: "1px solid #edf2f7" }}>
+                  <td style={{ padding: "8px 12px", color: "#4a5568", whiteSpace: "nowrap" }}>{log.created_at ? new Date(log.created_at).toLocaleString() : "-"}</td>
+                  <td style={{ padding: "8px 12px", color: "#4a5568", maxWidth: 200, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{log.message || "-"}</td>
+                  <td style={{ padding: "8px 12px", color: "#4a5568" }}>{log.model_used || "-"}</td>
+                  <td style={{ padding: "8px 12px", color: "#4a5568" }}>{(log.tokens_input || 0) + (log.tokens_output || 0)}</td>
+                  <td style={{ padding: "8px 12px", color: "#4a5568" }}>{log.latency_ms ? log.latency_ms + "ms" : "-"}</td>
+                  <td style={{ padding: "8px 12px" }}>
+                    <span style={{ background: log.status === "success" ? "#c6f6d5" : "#fed7d7", color: log.status === "success" ? "#22543d" : "#9b2c2c", padding: "2px 8px", borderRadius: 8, fontSize: 11, fontWeight: 600 }}>{log.status || "unknown"}</span>
+                  </td>
+                </tr>
+              ))}
+              {logs.length === 0 && <tr><td colSpan={6} style={{ padding: 16, textAlign: "center", color: "#a0aec0" }}>No audit logs yet</td></tr>}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/CornerstoneAgent.jsx
+++ b/frontend/src/pages/CornerstoneAgent.jsx
@@ -1,10 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { api } from "../lib/api.js";
 
-// ---------------------------------------------------------------------------
-// Constants & Styles
-// ---------------------------------------------------------------------------
-
 const QUICK_PROMPTS = [
   "Show me all Python files",
   "What is the project structure?",
@@ -12,78 +8,20 @@ const QUICK_PROMPTS = [
   "Read the main.py file",
 ];
 
-const cardStyle = {
-  background: "#fff",
-  borderRadius: 10,
-  boxShadow: "0 2px 12px rgba(0,0,0,0.06)",
-};
+const PROVIDERS = [
+  { value: "anthropic", label: "Anthropic (Claude)" },
+  { value: "openai", label: "OpenAI (GPT-4)" },
+  { value: "google", label: "Google (Gemini)" },
+];
 
-const clearBtnStyle = {
-  background: "transparent",
-  border: "1px solid #e2e8f0",
-  color: "#718096",
-  padding: "6px 14px",
-  borderRadius: 6,
-  cursor: "pointer",
-  fontSize: 13,
-  fontWeight: 500,
-};
-
-const toolBadgeStyle = {
-  background: "#ebf4ff",
-  color: "#3182ce",
-  padding: "3px 10px",
-  borderRadius: 12,
-  fontSize: 11,
-  fontWeight: 600,
-};
-
-const toolToggleStyle = {
-  background: "transparent",
-  border: "1px solid #e9d8fd",
-  color: "#805ad5",
-  padding: "4px 12px",
-  borderRadius: 6,
-  cursor: "pointer",
-  fontSize: 12,
-  fontWeight: 600,
-};
-
-const quickPromptStyle = {
-  background: "#ebf4ff",
-  border: "1px solid #bee3f8",
-  color: "#2b6cb0",
-  padding: "6px 14px",
-  borderRadius: 16,
-  cursor: "pointer",
-  fontSize: 13,
-  fontWeight: 500,
-};
-
-const sendBtnStyle = {
-  background: "#3182ce",
-  color: "#fff",
-  border: "none",
-  padding: "12px 24px",
-  borderRadius: 8,
-  cursor: "pointer",
-  fontWeight: 600,
-  fontSize: 14,
-  whiteSpace: "nowrap",
-};
-
-const dotStyle = {
-  width: 8,
-  height: 8,
-  borderRadius: "50%",
-  background: "#805ad5",
-  animation: "pulse 1.2s ease-in-out infinite",
-  display: "inline-block",
-};
-
-// ---------------------------------------------------------------------------
-// Component
-// ---------------------------------------------------------------------------
+const cardStyle = { background: "#fff", borderRadius: 10, boxShadow: "0 2px 12px rgba(0,0,0,0.06)" };
+const clearBtnStyle = { background: "transparent", border: "1px solid #e2e8f0", color: "#718096", padding: "6px 14px", borderRadius: 6, cursor: "pointer", fontSize: 13, fontWeight: 500 };
+const toolBadgeStyle = { background: "#ebf4ff", color: "#3182ce", padding: "3px 10px", borderRadius: 12, fontSize: 11, fontWeight: 600 };
+const toolToggleStyle = { background: "transparent", border: "1px solid #e9d8fd", color: "#805ad5", padding: "4px 12px", borderRadius: 6, cursor: "pointer", fontSize: 12, fontWeight: 600 };
+const quickPromptStyle = { background: "#ebf4ff", border: "1px solid #bee3f8", color: "#2b6cb0", padding: "6px 14px", borderRadius: 16, cursor: "pointer", fontSize: 13, fontWeight: 500 };
+const sendBtnStyle = { background: "#3182ce", color: "#fff", border: "none", padding: "12px 24px", borderRadius: 8, cursor: "pointer", fontWeight: 600, fontSize: 14, whiteSpace: "nowrap" };
+const dotStyle = { width: 8, height: 8, borderRadius: "50%", background: "#805ad5", animation: "pulse 1.2s ease-in-out infinite", display: "inline-block" };
+const selectStyle = { padding: "6px 10px", border: "1px solid #e2e8f0", borderRadius: 6, fontSize: 12, background: "#fff", color: "#4a5568", cursor: "pointer", outline: "none" };
 
 export default function CornerstoneAgent() {
   const [messages, setMessages] = useState([]);
@@ -92,444 +30,236 @@ export default function CornerstoneAgent() {
   const [agentInfo, setAgentInfo] = useState(null);
   const [history, setHistory] = useState([]);
   const [expandedTools, setExpandedTools] = useState({});
+  const [provider, setProvider] = useState("anthropic");
+  const [model, setModel] = useState("");
+  const [requireApproval, setRequireApproval] = useState(true);
+  const [pendingApprovals, setPendingApprovals] = useState(null);
+  const [subscription, setSubscription] = useState(null);
+  const [streamingText, setStreamingText] = useState("");
+  const [useStreaming, setUseStreaming] = useState(false);
   const bottomRef = useRef(null);
   const nextId = useRef(0);
 
   useEffect(() => {
     api.getAgentInfo().then(setAgentInfo).catch(() => {});
+    api.getSubscription().then(setSubscription).catch(() => {});
   }, []);
 
   useEffect(() => {
     bottomRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [messages, sending]);
+  }, [messages, sending, streamingText]);
 
   const handleSend = async (e) => {
     e.preventDefault();
     const text = input.trim();
     if (!text || sending) return;
-
-    const userMsg = {
-      id: nextId.current++,
-      role: "user",
-      content: text,
-      timestamp: new Date(),
-    };
+    const userMsg = { id: nextId.current++, role: "user", content: text, timestamp: new Date() };
     setMessages((prev) => [...prev, userMsg]);
     setInput("");
     setSending(true);
-
+    setStreamingText("");
     try {
-      const res = await api.sendAgentMessage(text, history);
-      const assistantMsg = {
-        id: nextId.current++,
-        role: "assistant",
-        content: res.response,
-        toolActions: res.tool_actions,
-        timestamp: new Date(),
-      };
-      setMessages((prev) => [...prev, assistantMsg]);
-      setHistory(res.history);
+      if (useStreaming) {
+        const res = await api.streamAgentMessage(text, history, model);
+        const reader = res.body.getReader();
+        const decoder = new TextDecoder();
+        let fullText = "";
+        let buffer = "";
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          buffer += decoder.decode(value, { stream: true });
+          const lines = buffer.split("\n");
+          buffer = lines.pop() || "";
+          for (const line of lines) {
+            if (line.startsWith("data: ")) {
+              const data = line.slice(6);
+              if (data === "[DONE]") break;
+              try {
+                const parsed = JSON.parse(data);
+                if (parsed.token) { fullText += parsed.token; setStreamingText(fullText); }
+                if (parsed.tool_actions) {
+                  setMessages((prev) => [...prev, { id: nextId.current++, role: "assistant", content: fullText || parsed.response || "", toolActions: parsed.tool_actions, tokens: parsed.tokens, timestamp: new Date() }]);
+                  if (parsed.history) setHistory(parsed.history);
+                }
+              } catch (_e) { /* ignore parse errors */ }
+            }
+          }
+        }
+        if (fullText) {
+          setMessages((prev) => [...prev, { id: nextId.current++, role: "assistant", content: fullText, timestamp: new Date() }]);
+        }
+        setStreamingText("");
+      } else {
+        const res = await api.sendAgentMessage(text, history, provider, model, requireApproval);
+        if (res.pending_approvals && res.pending_approvals.length > 0) {
+          setPendingApprovals(res.pending_approvals);
+          setMessages((prev) => [...prev, { id: nextId.current++, role: "assistant", content: "I need your approval to perform the following actions:", toolActions: res.tool_actions, pendingApprovals: res.pending_approvals, timestamp: new Date() }]);
+        } else {
+          setMessages((prev) => [...prev, { id: nextId.current++, role: "assistant", content: res.response, toolActions: res.tool_actions, tokens: res.tokens, timestamp: new Date() }]);
+          setHistory(res.history);
+        }
+      }
+      api.getSubscription().then(setSubscription).catch(() => {});
     } catch (err) {
-      const errorMsg = {
-        id: nextId.current++,
-        role: "assistant",
-        content:
-          err?.message ||
-          "An error occurred while communicating with the agent. Please check that the ANTHROPIC_API_KEY is configured.",
-        timestamp: new Date(),
-      };
-      setMessages((prev) => [...prev, errorMsg]);
-    } finally {
-      setSending(false);
-    }
+      setMessages((prev) => [...prev, { id: nextId.current++, role: "assistant", content: err?.message || "An error occurred.", timestamp: new Date() }]);
+    } finally { setSending(false); }
   };
 
-  const toggleTool = (msgId) => {
-    setExpandedTools((prev) => ({ ...prev, [msgId]: !prev[msgId] }));
+  const handleApproval = async (approved) => {
+    if (!pendingApprovals) return;
+    setSending(true);
+    try {
+      const res = await api.approveTools(pendingApprovals, approved);
+      setMessages((prev) => [...prev, { id: nextId.current++, role: "assistant", content: approved ? res.response : "Actions cancelled.", toolActions: res.tool_actions || [], timestamp: new Date() }]);
+      if (res.history) setHistory(res.history);
+    } catch (err) {
+      setMessages((prev) => [...prev, { id: nextId.current++, role: "assistant", content: err?.message || "Error processing approval.", timestamp: new Date() }]);
+    } finally { setPendingApprovals(null); setSending(false); }
   };
 
-  const handleClear = () => {
-    setMessages([]);
-    setHistory([]);
-    setExpandedTools({});
-  };
+  const toggleTool = (msgId) => setExpandedTools((prev) => ({ ...prev, [msgId]: !prev[msgId] }));
+  const handleClear = () => { setMessages([]); setHistory([]); setExpandedTools({}); setPendingApprovals(null); setStreamingText(""); };
 
   return (
-    <div
-      style={{
-        display: "flex",
-        flexDirection: "column",
-        height: "100vh",
-        maxWidth: 960,
-        margin: "0 auto",
-        padding: "16px 16px 0",
-      }}
-    >
+    <div style={{ display: "flex", flexDirection: "column", height: "100vh", maxWidth: 960, margin: "0 auto", padding: "16px 16px 0" }}>
       {/* Header */}
-      <div
-        style={{
-          display: "flex",
-          justifyContent: "space-between",
-          alignItems: "center",
-          marginBottom: 16,
-          flexWrap: "wrap",
-          gap: 8,
-        }}
-      >
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 12, flexWrap: "wrap", gap: 8 }}>
         <div>
-          <h2 style={{ margin: 0, color: "#2d3748", fontSize: 22 }}>
-            Cornerstone AI Agent
-          </h2>
-          <p style={{ margin: "4px 0 0", color: "#718096", fontSize: 13 }}>
-            Autonomous AI assistant — reads, writes, and manages your project
-            workspace
-          </p>
+          <h2 style={{ margin: 0, color: "#2d3748", fontSize: 22 }}>Cornerstone AI Agent</h2>
+          <p style={{ margin: "4px 0 0", color: "#718096", fontSize: 13 }}>Autonomous AI assistant with multi-model support</p>
         </div>
         <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
-          {agentInfo && (
-            <span
-              style={{
-                background:
-                  agentInfo.status === "online" ? "#c6f6d5" : "#fed7d7",
-                color:
-                  agentInfo.status === "online" ? "#22543d" : "#9b2c2c",
-                padding: "4px 12px",
-                borderRadius: 12,
-                fontSize: 12,
-                fontWeight: 600,
-              }}
-            >
-              {agentInfo.status.toUpperCase()}
-            </span>
-          )}
-          <button onClick={handleClear} style={clearBtnStyle}>
-            Clear Chat
-          </button>
+          {agentInfo && <span style={{ background: agentInfo.status === "online" ? "#c6f6d5" : "#fed7d7", color: agentInfo.status === "online" ? "#22543d" : "#9b2c2c", padding: "4px 12px", borderRadius: 12, fontSize: 12, fontWeight: 600 }}>{agentInfo.status.toUpperCase()}</span>}
+          <button onClick={handleClear} style={clearBtnStyle}>Clear Chat</button>
         </div>
       </div>
 
-      {/* Tool capabilities bar */}
-      {agentInfo && (
-        <div
-          style={{
-            ...cardStyle,
-            padding: "12px 16px",
-            marginBottom: 16,
-            display: "flex",
-            gap: 8,
-            flexWrap: "wrap",
-            alignItems: "center",
-          }}
-        >
-          <span
-            style={{
-              fontSize: 12,
-              color: "#718096",
-              fontWeight: 600,
-              marginRight: 4,
-            }}
-          >
-            Tools:
-          </span>
-          {agentInfo.tools.map((tool) => (
-            <span key={tool} style={toolBadgeStyle}>
-              {tool}
-            </span>
-          ))}
+      {/* Controls bar */}
+      <div style={{ ...cardStyle, padding: "10px 16px", marginBottom: 12, display: "flex", gap: 12, flexWrap: "wrap", alignItems: "center" }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+          <label style={{ fontSize: 12, color: "#718096", fontWeight: 600 }}>Provider:</label>
+          <select value={provider} onChange={(e) => { setProvider(e.target.value); setModel(""); }} style={selectStyle}>
+            {PROVIDERS.map((p) => <option key={p.value} value={p.value}>{p.label}</option>)}
+          </select>
+        </div>
+        <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+          <label style={{ fontSize: 12, color: "#718096", fontWeight: 600 }}>Model:</label>
+          <select value={model} onChange={(e) => setModel(e.target.value)} style={selectStyle}>
+            <option value="">Default</option>
+            {agentInfo?.providers?.[provider]?.models?.map((m) => <option key={m} value={m}>{m}</option>)}
+          </select>
+        </div>
+        <label style={{ display: "flex", alignItems: "center", gap: 4, fontSize: 12, color: "#718096", cursor: "pointer" }}>
+          <input type="checkbox" checked={requireApproval} onChange={(e) => setRequireApproval(e.target.checked)} /> Require approval
+        </label>
+        <label style={{ display: "flex", alignItems: "center", gap: 4, fontSize: 12, color: "#718096", cursor: "pointer" }}>
+          <input type="checkbox" checked={useStreaming} onChange={(e) => setUseStreaming(e.target.checked)} /> Streaming
+        </label>
+        {subscription && (
+          <div style={{ marginLeft: "auto", display: "flex", alignItems: "center", gap: 8 }}>
+            <span style={{ background: subscription.tier === "free" ? "#ebf4ff" : "#f0fff4", color: subscription.tier === "free" ? "#3182ce" : "#276749", padding: "3px 10px", borderRadius: 12, fontSize: 11, fontWeight: 600, textTransform: "uppercase" }}>{subscription.tier}</span>
+            <span style={{ fontSize: 11, color: "#a0aec0" }}>{subscription.messages_used}/{subscription.messages_limit} msgs</span>
+            <div style={{ width: 60, height: 6, background: "#e2e8f0", borderRadius: 3, overflow: "hidden" }}>
+              <div style={{ width: Math.min(100, (subscription.messages_used / subscription.messages_limit) * 100) + "%", height: "100%", background: (subscription.messages_used / subscription.messages_limit) > 0.8 ? "#e53e3e" : "#48bb78", borderRadius: 3 }} />
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Tool capabilities */}
+      {agentInfo && agentInfo.tools && (
+        <div style={{ ...cardStyle, padding: "10px 16px", marginBottom: 12, display: "flex", gap: 8, flexWrap: "wrap", alignItems: "center" }}>
+          <span style={{ fontSize: 12, color: "#718096", fontWeight: 600, marginRight: 4 }}>Tools:</span>
+          {agentInfo.tools.map((tool) => <span key={tool} style={toolBadgeStyle}>{tool}</span>)}
         </div>
       )}
 
-      {/* Chat messages */}
-      <div
-        style={{
-          flex: 1,
-          overflowY: "auto",
-          marginBottom: 16,
-          paddingBottom: 8,
-        }}
-      >
+      {/* Chat area */}
+      <div style={{ flex: 1, overflowY: "auto", marginBottom: 16, paddingBottom: 8 }}>
         {messages.length === 0 && !sending && (
-          <div
-            style={{
-              ...cardStyle,
-              textAlign: "center",
-              padding: 48,
-              marginTop: 32,
-            }}
-          >
+          <div style={{ ...cardStyle, textAlign: "center", padding: 48, marginTop: 32 }}>
             <div style={{ fontSize: 40, marginBottom: 16 }}>{"</>"}</div>
-            <h3 style={{ margin: "0 0 8px", color: "#2d3748" }}>
-              Welcome to Cornerstone AI Agent
-            </h3>
-            <p
-              style={{
-                margin: 0,
-                color: "#718096",
-                fontSize: 14,
-                maxWidth: 480,
-                marginLeft: "auto",
-                marginRight: "auto",
-              }}
-            >
-              Ask me to read files, write code, run commands, search your
-              codebase, or manage your project. I can help you build, debug,
-              and maintain the Cornerstone Platform.
-            </p>
-            <div
-              style={{
-                display: "flex",
-                flexWrap: "wrap",
-                gap: 8,
-                justifyContent: "center",
-                marginTop: 20,
-              }}
-            >
-              {QUICK_PROMPTS.map((prompt) => (
-                <button
-                  key={prompt}
-                  onClick={() => setInput(prompt)}
-                  style={quickPromptStyle}
-                >
-                  {prompt}
-                </button>
-              ))}
+            <h3 style={{ margin: "0 0 8px", color: "#2d3748" }}>Welcome to Cornerstone AI Agent</h3>
+            <p style={{ margin: 0, color: "#718096", fontSize: 14, maxWidth: 480, marginLeft: "auto", marginRight: "auto" }}>Ask me to read files, write code, run commands, search your codebase, or manage your project.</p>
+            <div style={{ display: "flex", flexWrap: "wrap", gap: 8, justifyContent: "center", marginTop: 20 }}>
+              {QUICK_PROMPTS.map((prompt) => <button key={prompt} onClick={() => setInput(prompt)} style={quickPromptStyle}>{prompt}</button>)}
             </div>
           </div>
         )}
 
         {messages.map((msg) => (
-          <div
-            key={msg.id}
-            style={{
-              marginBottom: 16,
-              display: "flex",
-              flexDirection: "column",
-              alignItems: msg.role === "user" ? "flex-end" : "flex-start",
-            }}
-          >
-            <div
-              style={{
-                ...cardStyle,
-                maxWidth: "85%",
-                padding: "12px 16px",
-                background: msg.role === "user" ? "#3182ce" : "#fff",
-                color: msg.role === "user" ? "#fff" : "#2d3748",
-                borderRadius:
-                  msg.role === "user"
-                    ? "16px 16px 4px 16px"
-                    : "16px 16px 16px 4px",
-              }}
-            >
-              <div
-                style={{
-                  fontSize: 11,
-                  fontWeight: 600,
-                  marginBottom: 4,
-                  opacity: 0.7,
-                }}
-              >
-                {msg.role === "user" ? "You" : "Cornerstone AI"}
-              </div>
-              <div
-                style={{
-                  fontSize: 14,
-                  whiteSpace: "pre-wrap",
-                  lineHeight: 1.6,
-                }}
-              >
-                {msg.content}
-              </div>
+          <div key={msg.id} style={{ marginBottom: 16, display: "flex", flexDirection: "column", alignItems: msg.role === "user" ? "flex-end" : "flex-start" }}>
+            <div style={{ ...cardStyle, maxWidth: "85%", padding: "12px 16px", background: msg.role === "user" ? "#3182ce" : "#fff", color: msg.role === "user" ? "#fff" : "#2d3748", borderRadius: msg.role === "user" ? "16px 16px 4px 16px" : "16px 16px 16px 4px" }}>
+              <div style={{ fontSize: 11, fontWeight: 600, marginBottom: 4, opacity: 0.7 }}>{msg.role === "user" ? "You" : "Cornerstone AI"}</div>
+              <div style={{ fontSize: 14, whiteSpace: "pre-wrap", lineHeight: 1.6 }}>{msg.content}</div>
+              {msg.tokens && <div style={{ marginTop: 6, fontSize: 10, color: msg.role === "user" ? "rgba(255,255,255,0.6)" : "#a0aec0" }}>Tokens: {msg.tokens.input_tokens} in / {msg.tokens.output_tokens} out</div>}
             </div>
-
+            {/* Approval UI */}
+            {msg.pendingApprovals && pendingApprovals && (
+              <div style={{ maxWidth: "85%", marginTop: 8, display: "flex", flexDirection: "column", gap: 8 }}>
+                {msg.pendingApprovals.map((a, i) => (
+                  <div key={i} style={{ ...cardStyle, padding: "10px 14px", background: "#fffaf0", borderLeft: "3px solid #ed8936" }}>
+                    <div style={{ fontSize: 12, fontWeight: 700, color: "#c05621" }}>{a.tool}</div>
+                    <code style={{ fontSize: 11, color: "#744210" }}>{JSON.stringify(a.input).slice(0, 200)}</code>
+                  </div>
+                ))}
+                <div style={{ display: "flex", gap: 8 }}>
+                  <button onClick={() => handleApproval(true)} style={{ background: "#48bb78", color: "#fff", border: "none", padding: "8px 20px", borderRadius: 6, cursor: "pointer", fontWeight: 600, fontSize: 13 }}>Approve</button>
+                  <button onClick={() => handleApproval(false)} style={{ background: "#fc8181", color: "#fff", border: "none", padding: "8px 20px", borderRadius: 6, cursor: "pointer", fontWeight: 600, fontSize: 13 }}>Reject</button>
+                </div>
+              </div>
+            )}
             {/* Tool actions */}
             {msg.toolActions && msg.toolActions.length > 0 && (
               <div style={{ maxWidth: "85%", marginTop: 6 }}>
-                <button
-                  onClick={() => toggleTool(msg.id)}
-                  style={toolToggleStyle}
-                >
-                  {expandedTools[msg.id] ? "Hide" : "Show"}{" "}
-                  {msg.toolActions.length} tool action
-                  {msg.toolActions.length > 1 ? "s" : ""}
-                </button>
+                <button onClick={() => toggleTool(msg.id)} style={toolToggleStyle}>{expandedTools[msg.id] ? "Hide" : "Show"} {msg.toolActions.length} tool action{msg.toolActions.length > 1 ? "s" : ""}</button>
                 {expandedTools[msg.id] && (
-                  <div
-                    style={{
-                      marginTop: 6,
-                      display: "flex",
-                      flexDirection: "column",
-                      gap: 8,
-                    }}
-                  >
+                  <div style={{ marginTop: 6, display: "flex", flexDirection: "column", gap: 8 }}>
                     {msg.toolActions.map((action, i) => (
-                      <div
-                        key={i}
-                        style={{
-                          ...cardStyle,
-                          padding: "10px 14px",
-                          background: "#f7fafc",
-                          borderLeft: "3px solid #805ad5",
-                        }}
-                      >
-                        <div
-                          style={{
-                            fontSize: 12,
-                            fontWeight: 700,
-                            color: "#805ad5",
-                            marginBottom: 4,
-                          }}
-                        >
-                          {action.tool}
-                        </div>
-                        <div
-                          style={{
-                            fontSize: 12,
-                            color: "#4a5568",
-                            marginBottom: 4,
-                          }}
-                        >
-                          <strong>Input:</strong>{" "}
-                          <code
-                            style={{
-                              background: "#edf2f7",
-                              padding: "1px 4px",
-                              borderRadius: 3,
-                              fontSize: 11,
-                            }}
-                          >
-                            {JSON.stringify(action.input).slice(0, 200)}
-                            {JSON.stringify(action.input).length > 200
-                              ? "..."
-                              : ""}
-                          </code>
-                        </div>
-                        <div style={{ fontSize: 12, color: "#4a5568" }}>
-                          <strong>Output:</strong>
-                          <pre
-                            style={{
-                              margin: "4px 0 0",
-                              fontSize: 11,
-                              background: "#edf2f7",
-                              padding: 8,
-                              borderRadius: 4,
-                              overflowX: "auto",
-                              maxHeight: 200,
-                              whiteSpace: "pre-wrap",
-                            }}
-                          >
-                            {action.output.slice(0, 1000)}
-                            {action.output.length > 1000
-                              ? "\n...(truncated)"
-                              : ""}
-                          </pre>
-                        </div>
+                      <div key={i} style={{ ...cardStyle, padding: "10px 14px", background: "#f7fafc", borderLeft: "3px solid #805ad5" }}>
+                        <div style={{ fontSize: 12, fontWeight: 700, color: "#805ad5", marginBottom: 4 }}>{action.tool}</div>
+                        <div style={{ fontSize: 12, color: "#4a5568", marginBottom: 4 }}><strong>Input:</strong> <code style={{ background: "#edf2f7", padding: "1px 4px", borderRadius: 3, fontSize: 11 }}>{JSON.stringify(action.input).slice(0, 200)}</code></div>
+                        <div style={{ fontSize: 12, color: "#4a5568" }}><strong>Output:</strong><pre style={{ margin: "4px 0 0", fontSize: 11, background: "#edf2f7", padding: 8, borderRadius: 4, overflowX: "auto", maxHeight: 200, whiteSpace: "pre-wrap" }}>{action.output.slice(0, 1000)}{action.output.length > 1000 ? "\n...(truncated)" : ""}</pre></div>
                       </div>
                     ))}
                   </div>
                 )}
               </div>
             )}
-
-            <div
-              style={{
-                fontSize: 10,
-                color: "#a0aec0",
-                marginTop: 4,
-                paddingLeft: 4,
-                paddingRight: 4,
-              }}
-            >
-              {msg.timestamp.toLocaleTimeString()}
-            </div>
+            <div style={{ fontSize: 10, color: "#a0aec0", marginTop: 4, paddingLeft: 4 }}>{msg.timestamp.toLocaleTimeString()}</div>
           </div>
         ))}
 
-        {sending && (
-          <div
-            style={{
-              display: "flex",
-              alignItems: "flex-start",
-              marginBottom: 16,
-            }}
-          >
-            <div
-              style={{
-                ...cardStyle,
-                padding: "12px 16px",
-                borderRadius: "16px 16px 16px 4px",
-              }}
-            >
-              <div
-                style={{
-                  fontSize: 11,
-                  fontWeight: 600,
-                  marginBottom: 4,
-                  color: "#718096",
-                }}
-              >
-                Cornerstone AI
-              </div>
-              <div style={{ display: "flex", gap: 4, alignItems: "center" }}>
-                <span style={dotStyle} />
-                <span style={{ ...dotStyle, animationDelay: "0.2s" }} />
-                <span style={{ ...dotStyle, animationDelay: "0.4s" }} />
-                <span
-                  style={{ fontSize: 13, color: "#718096", marginLeft: 8 }}
-                >
-                  Thinking...
-                </span>
-              </div>
+        {sending && streamingText && (
+          <div style={{ marginBottom: 16, display: "flex", flexDirection: "column", alignItems: "flex-start" }}>
+            <div style={{ ...cardStyle, maxWidth: "85%", padding: "12px 16px", borderRadius: "16px 16px 16px 4px" }}>
+              <div style={{ fontSize: 11, fontWeight: 600, marginBottom: 4, color: "#718096" }}>Cornerstone AI</div>
+              <div style={{ fontSize: 14, whiteSpace: "pre-wrap", lineHeight: 1.6 }}>{streamingText}<span style={{ ...dotStyle, marginLeft: 2 }} /></div>
             </div>
           </div>
         )}
 
+        {sending && !streamingText && (
+          <div style={{ display: "flex", alignItems: "flex-start", marginBottom: 16 }}>
+            <div style={{ ...cardStyle, padding: "12px 16px", borderRadius: "16px 16px 16px 4px" }}>
+              <div style={{ fontSize: 11, fontWeight: 600, marginBottom: 4, color: "#718096" }}>Cornerstone AI</div>
+              <div style={{ display: "flex", gap: 4, alignItems: "center" }}>
+                <span style={dotStyle} /><span style={{ ...dotStyle, animationDelay: "0.2s" }} /><span style={{ ...dotStyle, animationDelay: "0.4s" }} />
+                <span style={{ fontSize: 13, color: "#718096", marginLeft: 8 }}>Thinking...</span>
+              </div>
+            </div>
+          </div>
+        )}
         <div ref={bottomRef} />
       </div>
 
-      {/* Input area */}
-      <form
-        onSubmit={handleSend}
-        style={{
-          display: "flex",
-          gap: 8,
-          padding: "12px 0 16px",
-          borderTop: "1px solid #e2e8f0",
-        }}
-      >
-        <input
-          value={input}
-          onChange={(e) => setInput(e.target.value)}
-          placeholder="Ask the Cornerstone AI Agent..."
-          disabled={sending}
-          style={{
-            flex: 1,
-            padding: "12px 16px",
-            border: "1px solid #e2e8f0",
-            borderRadius: 8,
-            fontSize: 14,
-            outline: "none",
-            boxSizing: "border-box",
-          }}
-        />
-        <button
-          type="submit"
-          disabled={sending || !input.trim()}
-          style={{
-            ...sendBtnStyle,
-            opacity: sending || !input.trim() ? 0.5 : 1,
-          }}
-        >
-          {sending ? "Sending..." : "Send"}
-        </button>
+      {/* Input */}
+      <form onSubmit={handleSend} style={{ display: "flex", gap: 8, padding: "12px 0 16px", borderTop: "1px solid #e2e8f0" }}>
+        <input value={input} onChange={(e) => setInput(e.target.value)} placeholder="Ask the Cornerstone AI Agent..." disabled={sending} style={{ flex: 1, padding: "12px 16px", border: "1px solid #e2e8f0", borderRadius: 8, fontSize: 14, outline: "none", boxSizing: "border-box" }} />
+        <button type="submit" disabled={sending || !input.trim()} style={{ ...sendBtnStyle, opacity: sending || !input.trim() ? 0.5 : 1 }}>{sending ? "Sending..." : "Send"}</button>
       </form>
-
-      {/* Animations */}
-      <style>{`
-        @keyframes pulse {
-          0%, 100% { opacity: 0.3; }
-          50% { opacity: 1; }
-        }
-      `}</style>
+      <style>{`@keyframes pulse { 0%, 100% { opacity: 0.3; } 50% { opacity: 1; } }`}</style>
     </div>
   );
 }

--- a/frontend/src/pages/CornerstoneAgent.jsx
+++ b/frontend/src/pages/CornerstoneAgent.jsx
@@ -1,0 +1,535 @@
+import { useEffect, useRef, useState } from "react";
+import { api } from "../lib/api.js";
+
+// ---------------------------------------------------------------------------
+// Constants & Styles
+// ---------------------------------------------------------------------------
+
+const QUICK_PROMPTS = [
+  "Show me all Python files",
+  "What is the project structure?",
+  "Check git status",
+  "Read the main.py file",
+];
+
+const cardStyle = {
+  background: "#fff",
+  borderRadius: 10,
+  boxShadow: "0 2px 12px rgba(0,0,0,0.06)",
+};
+
+const clearBtnStyle = {
+  background: "transparent",
+  border: "1px solid #e2e8f0",
+  color: "#718096",
+  padding: "6px 14px",
+  borderRadius: 6,
+  cursor: "pointer",
+  fontSize: 13,
+  fontWeight: 500,
+};
+
+const toolBadgeStyle = {
+  background: "#ebf4ff",
+  color: "#3182ce",
+  padding: "3px 10px",
+  borderRadius: 12,
+  fontSize: 11,
+  fontWeight: 600,
+};
+
+const toolToggleStyle = {
+  background: "transparent",
+  border: "1px solid #e9d8fd",
+  color: "#805ad5",
+  padding: "4px 12px",
+  borderRadius: 6,
+  cursor: "pointer",
+  fontSize: 12,
+  fontWeight: 600,
+};
+
+const quickPromptStyle = {
+  background: "#ebf4ff",
+  border: "1px solid #bee3f8",
+  color: "#2b6cb0",
+  padding: "6px 14px",
+  borderRadius: 16,
+  cursor: "pointer",
+  fontSize: 13,
+  fontWeight: 500,
+};
+
+const sendBtnStyle = {
+  background: "#3182ce",
+  color: "#fff",
+  border: "none",
+  padding: "12px 24px",
+  borderRadius: 8,
+  cursor: "pointer",
+  fontWeight: 600,
+  fontSize: 14,
+  whiteSpace: "nowrap",
+};
+
+const dotStyle = {
+  width: 8,
+  height: 8,
+  borderRadius: "50%",
+  background: "#805ad5",
+  animation: "pulse 1.2s ease-in-out infinite",
+  display: "inline-block",
+};
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export default function CornerstoneAgent() {
+  const [messages, setMessages] = useState([]);
+  const [input, setInput] = useState("");
+  const [sending, setSending] = useState(false);
+  const [agentInfo, setAgentInfo] = useState(null);
+  const [history, setHistory] = useState([]);
+  const [expandedTools, setExpandedTools] = useState({});
+  const bottomRef = useRef(null);
+  const nextId = useRef(0);
+
+  useEffect(() => {
+    api.getAgentInfo().then(setAgentInfo).catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages, sending]);
+
+  const handleSend = async (e) => {
+    e.preventDefault();
+    const text = input.trim();
+    if (!text || sending) return;
+
+    const userMsg = {
+      id: nextId.current++,
+      role: "user",
+      content: text,
+      timestamp: new Date(),
+    };
+    setMessages((prev) => [...prev, userMsg]);
+    setInput("");
+    setSending(true);
+
+    try {
+      const res = await api.sendAgentMessage(text, history);
+      const assistantMsg = {
+        id: nextId.current++,
+        role: "assistant",
+        content: res.response,
+        toolActions: res.tool_actions,
+        timestamp: new Date(),
+      };
+      setMessages((prev) => [...prev, assistantMsg]);
+      setHistory(res.history);
+    } catch (err) {
+      const errorMsg = {
+        id: nextId.current++,
+        role: "assistant",
+        content:
+          err?.message ||
+          "An error occurred while communicating with the agent. Please check that the ANTHROPIC_API_KEY is configured.",
+        timestamp: new Date(),
+      };
+      setMessages((prev) => [...prev, errorMsg]);
+    } finally {
+      setSending(false);
+    }
+  };
+
+  const toggleTool = (msgId) => {
+    setExpandedTools((prev) => ({ ...prev, [msgId]: !prev[msgId] }));
+  };
+
+  const handleClear = () => {
+    setMessages([]);
+    setHistory([]);
+    setExpandedTools({});
+  };
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        height: "100vh",
+        maxWidth: 960,
+        margin: "0 auto",
+        padding: "16px 16px 0",
+      }}
+    >
+      {/* Header */}
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          marginBottom: 16,
+          flexWrap: "wrap",
+          gap: 8,
+        }}
+      >
+        <div>
+          <h2 style={{ margin: 0, color: "#2d3748", fontSize: 22 }}>
+            Cornerstone AI Agent
+          </h2>
+          <p style={{ margin: "4px 0 0", color: "#718096", fontSize: 13 }}>
+            Autonomous AI assistant — reads, writes, and manages your project
+            workspace
+          </p>
+        </div>
+        <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+          {agentInfo && (
+            <span
+              style={{
+                background:
+                  agentInfo.status === "online" ? "#c6f6d5" : "#fed7d7",
+                color:
+                  agentInfo.status === "online" ? "#22543d" : "#9b2c2c",
+                padding: "4px 12px",
+                borderRadius: 12,
+                fontSize: 12,
+                fontWeight: 600,
+              }}
+            >
+              {agentInfo.status.toUpperCase()}
+            </span>
+          )}
+          <button onClick={handleClear} style={clearBtnStyle}>
+            Clear Chat
+          </button>
+        </div>
+      </div>
+
+      {/* Tool capabilities bar */}
+      {agentInfo && (
+        <div
+          style={{
+            ...cardStyle,
+            padding: "12px 16px",
+            marginBottom: 16,
+            display: "flex",
+            gap: 8,
+            flexWrap: "wrap",
+            alignItems: "center",
+          }}
+        >
+          <span
+            style={{
+              fontSize: 12,
+              color: "#718096",
+              fontWeight: 600,
+              marginRight: 4,
+            }}
+          >
+            Tools:
+          </span>
+          {agentInfo.tools.map((tool) => (
+            <span key={tool} style={toolBadgeStyle}>
+              {tool}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {/* Chat messages */}
+      <div
+        style={{
+          flex: 1,
+          overflowY: "auto",
+          marginBottom: 16,
+          paddingBottom: 8,
+        }}
+      >
+        {messages.length === 0 && !sending && (
+          <div
+            style={{
+              ...cardStyle,
+              textAlign: "center",
+              padding: 48,
+              marginTop: 32,
+            }}
+          >
+            <div style={{ fontSize: 40, marginBottom: 16 }}>{"</>"}</div>
+            <h3 style={{ margin: "0 0 8px", color: "#2d3748" }}>
+              Welcome to Cornerstone AI Agent
+            </h3>
+            <p
+              style={{
+                margin: 0,
+                color: "#718096",
+                fontSize: 14,
+                maxWidth: 480,
+                marginLeft: "auto",
+                marginRight: "auto",
+              }}
+            >
+              Ask me to read files, write code, run commands, search your
+              codebase, or manage your project. I can help you build, debug,
+              and maintain the Cornerstone Platform.
+            </p>
+            <div
+              style={{
+                display: "flex",
+                flexWrap: "wrap",
+                gap: 8,
+                justifyContent: "center",
+                marginTop: 20,
+              }}
+            >
+              {QUICK_PROMPTS.map((prompt) => (
+                <button
+                  key={prompt}
+                  onClick={() => setInput(prompt)}
+                  style={quickPromptStyle}
+                >
+                  {prompt}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {messages.map((msg) => (
+          <div
+            key={msg.id}
+            style={{
+              marginBottom: 16,
+              display: "flex",
+              flexDirection: "column",
+              alignItems: msg.role === "user" ? "flex-end" : "flex-start",
+            }}
+          >
+            <div
+              style={{
+                ...cardStyle,
+                maxWidth: "85%",
+                padding: "12px 16px",
+                background: msg.role === "user" ? "#3182ce" : "#fff",
+                color: msg.role === "user" ? "#fff" : "#2d3748",
+                borderRadius:
+                  msg.role === "user"
+                    ? "16px 16px 4px 16px"
+                    : "16px 16px 16px 4px",
+              }}
+            >
+              <div
+                style={{
+                  fontSize: 11,
+                  fontWeight: 600,
+                  marginBottom: 4,
+                  opacity: 0.7,
+                }}
+              >
+                {msg.role === "user" ? "You" : "Cornerstone AI"}
+              </div>
+              <div
+                style={{
+                  fontSize: 14,
+                  whiteSpace: "pre-wrap",
+                  lineHeight: 1.6,
+                }}
+              >
+                {msg.content}
+              </div>
+            </div>
+
+            {/* Tool actions */}
+            {msg.toolActions && msg.toolActions.length > 0 && (
+              <div style={{ maxWidth: "85%", marginTop: 6 }}>
+                <button
+                  onClick={() => toggleTool(msg.id)}
+                  style={toolToggleStyle}
+                >
+                  {expandedTools[msg.id] ? "Hide" : "Show"}{" "}
+                  {msg.toolActions.length} tool action
+                  {msg.toolActions.length > 1 ? "s" : ""}
+                </button>
+                {expandedTools[msg.id] && (
+                  <div
+                    style={{
+                      marginTop: 6,
+                      display: "flex",
+                      flexDirection: "column",
+                      gap: 8,
+                    }}
+                  >
+                    {msg.toolActions.map((action, i) => (
+                      <div
+                        key={i}
+                        style={{
+                          ...cardStyle,
+                          padding: "10px 14px",
+                          background: "#f7fafc",
+                          borderLeft: "3px solid #805ad5",
+                        }}
+                      >
+                        <div
+                          style={{
+                            fontSize: 12,
+                            fontWeight: 700,
+                            color: "#805ad5",
+                            marginBottom: 4,
+                          }}
+                        >
+                          {action.tool}
+                        </div>
+                        <div
+                          style={{
+                            fontSize: 12,
+                            color: "#4a5568",
+                            marginBottom: 4,
+                          }}
+                        >
+                          <strong>Input:</strong>{" "}
+                          <code
+                            style={{
+                              background: "#edf2f7",
+                              padding: "1px 4px",
+                              borderRadius: 3,
+                              fontSize: 11,
+                            }}
+                          >
+                            {JSON.stringify(action.input).slice(0, 200)}
+                            {JSON.stringify(action.input).length > 200
+                              ? "..."
+                              : ""}
+                          </code>
+                        </div>
+                        <div style={{ fontSize: 12, color: "#4a5568" }}>
+                          <strong>Output:</strong>
+                          <pre
+                            style={{
+                              margin: "4px 0 0",
+                              fontSize: 11,
+                              background: "#edf2f7",
+                              padding: 8,
+                              borderRadius: 4,
+                              overflowX: "auto",
+                              maxHeight: 200,
+                              whiteSpace: "pre-wrap",
+                            }}
+                          >
+                            {action.output.slice(0, 1000)}
+                            {action.output.length > 1000
+                              ? "\n...(truncated)"
+                              : ""}
+                          </pre>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
+
+            <div
+              style={{
+                fontSize: 10,
+                color: "#a0aec0",
+                marginTop: 4,
+                paddingLeft: 4,
+                paddingRight: 4,
+              }}
+            >
+              {msg.timestamp.toLocaleTimeString()}
+            </div>
+          </div>
+        ))}
+
+        {sending && (
+          <div
+            style={{
+              display: "flex",
+              alignItems: "flex-start",
+              marginBottom: 16,
+            }}
+          >
+            <div
+              style={{
+                ...cardStyle,
+                padding: "12px 16px",
+                borderRadius: "16px 16px 16px 4px",
+              }}
+            >
+              <div
+                style={{
+                  fontSize: 11,
+                  fontWeight: 600,
+                  marginBottom: 4,
+                  color: "#718096",
+                }}
+              >
+                Cornerstone AI
+              </div>
+              <div style={{ display: "flex", gap: 4, alignItems: "center" }}>
+                <span style={dotStyle} />
+                <span style={{ ...dotStyle, animationDelay: "0.2s" }} />
+                <span style={{ ...dotStyle, animationDelay: "0.4s" }} />
+                <span
+                  style={{ fontSize: 13, color: "#718096", marginLeft: 8 }}
+                >
+                  Thinking...
+                </span>
+              </div>
+            </div>
+          </div>
+        )}
+
+        <div ref={bottomRef} />
+      </div>
+
+      {/* Input area */}
+      <form
+        onSubmit={handleSend}
+        style={{
+          display: "flex",
+          gap: 8,
+          padding: "12px 0 16px",
+          borderTop: "1px solid #e2e8f0",
+        }}
+      >
+        <input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="Ask the Cornerstone AI Agent..."
+          disabled={sending}
+          style={{
+            flex: 1,
+            padding: "12px 16px",
+            border: "1px solid #e2e8f0",
+            borderRadius: 8,
+            fontSize: 14,
+            outline: "none",
+            boxSizing: "border-box",
+          }}
+        />
+        <button
+          type="submit"
+          disabled={sending || !input.trim()}
+          style={{
+            ...sendBtnStyle,
+            opacity: sending || !input.trim() ? 0.5 : 1,
+          }}
+        >
+          {sending ? "Sending..." : "Send"}
+        </button>
+      </form>
+
+      {/* Animations */}
+      <style>{`
+        @keyframes pulse {
+          0%, 100% { opacity: 0.3; }
+          50% { opacity: 1; }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/frontend/src/pages/CornerstoneAgent.jsx
+++ b/frontend/src/pages/CornerstoneAgent.jsx
@@ -77,7 +77,7 @@ export default function CornerstoneAgent() {
               if (data === "[DONE]") break;
               try {
                 const parsed = JSON.parse(data);
-                if (parsed.token) { fullText += parsed.token; setStreamingText(fullText); }
+                if (parsed.token || parsed.content) { fullText += (parsed.token || parsed.content); setStreamingText(fullText); }
                 if (parsed.tool_actions) {
                   setMessages((prev) => [...prev, { id: nextId.current++, role: "assistant", content: fullText || parsed.response || "", toolActions: parsed.tool_actions, tokens: parsed.tokens, timestamp: new Date() }]);
                   if (parsed.history) setHistory(parsed.history);
@@ -96,7 +96,7 @@ export default function CornerstoneAgent() {
           setPendingApprovals(res.pending_approvals);
           setMessages((prev) => [...prev, { id: nextId.current++, role: "assistant", content: "I need your approval to perform the following actions:", toolActions: res.tool_actions, pendingApprovals: res.pending_approvals, timestamp: new Date() }]);
         } else {
-          setMessages((prev) => [...prev, { id: nextId.current++, role: "assistant", content: res.response, toolActions: res.tool_actions, tokens: res.tokens, timestamp: new Date() }]);
+          setMessages((prev) => [...prev, { id: nextId.current++, role: "assistant", content: res.response, toolActions: res.tool_actions, tokens: res.tokens_input != null ? { input_tokens: res.tokens_input, output_tokens: res.tokens_output } : res.tokens, timestamp: new Date() }]);
           setHistory(res.history);
         }
       }

--- a/frontend/src/pages/CornerstoneAgentPage.tsx
+++ b/frontend/src/pages/CornerstoneAgentPage.tsx
@@ -1,0 +1,358 @@
+import React, { useEffect, useRef, useState } from 'react';
+import {
+  sendAgentMessage,
+  getAgentInfo,
+  AgentToolAction,
+  AgentInfo,
+} from '../services/api';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface ChatMessage {
+  id: number;
+  role: 'user' | 'assistant';
+  content: string;
+  toolActions?: AgentToolAction[];
+  timestamp: Date;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function CornerstoneAgentPage() {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [input, setInput] = useState('');
+  const [sending, setSending] = useState(false);
+  const [agentInfo, setAgentInfo] = useState<AgentInfo | null>(null);
+  const [history, setHistory] = useState<Array<Record<string, any>>>([]);
+  const [expandedTools, setExpandedTools] = useState<Record<number, boolean>>({});
+  const bottomRef = useRef<HTMLDivElement>(null);
+  let nextId = useRef(0);
+
+  useEffect(() => {
+    getAgentInfo()
+      .then(setAgentInfo)
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages, sending]);
+
+  const handleSend = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const text = input.trim();
+    if (!text || sending) return;
+
+    const userMsg: ChatMessage = {
+      id: nextId.current++,
+      role: 'user',
+      content: text,
+      timestamp: new Date(),
+    };
+    setMessages((prev) => [...prev, userMsg]);
+    setInput('');
+    setSending(true);
+
+    try {
+      const res = await sendAgentMessage(text, history);
+      const assistantMsg: ChatMessage = {
+        id: nextId.current++,
+        role: 'assistant',
+        content: res.response,
+        toolActions: res.tool_actions,
+        timestamp: new Date(),
+      };
+      setMessages((prev) => [...prev, assistantMsg]);
+      setHistory(res.history);
+    } catch (err: any) {
+      const errorMsg: ChatMessage = {
+        id: nextId.current++,
+        role: 'assistant',
+        content:
+          err?.response?.data?.detail ||
+          'An error occurred while communicating with the agent. Please check that the ANTHROPIC_API_KEY is configured.',
+        timestamp: new Date(),
+      };
+      setMessages((prev) => [...prev, errorMsg]);
+    } finally {
+      setSending(false);
+    }
+  };
+
+  const toggleTool = (msgId: number) => {
+    setExpandedTools((prev) => ({ ...prev, [msgId]: !prev[msgId] }));
+  };
+
+  const handleClear = () => {
+    setMessages([]);
+    setHistory([]);
+    setExpandedTools({});
+  };
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100vh', maxWidth: 960, margin: '0 auto', padding: '16px 16px 0' }}>
+      {/* Header */}
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16, flexWrap: 'wrap', gap: 8 }}>
+        <div>
+          <h2 style={{ margin: 0, color: '#2d3748', fontSize: 22 }}>Cornerstone AI Agent</h2>
+          <p style={{ margin: '4px 0 0', color: '#718096', fontSize: 13 }}>
+            Autonomous AI assistant — reads, writes, and manages your project workspace
+          </p>
+        </div>
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+          {agentInfo && (
+            <span
+              style={{
+                background: agentInfo.status === 'online' ? '#c6f6d5' : '#fed7d7',
+                color: agentInfo.status === 'online' ? '#22543d' : '#9b2c2c',
+                padding: '4px 12px',
+                borderRadius: 12,
+                fontSize: 12,
+                fontWeight: 600,
+              }}
+            >
+              {agentInfo.status.toUpperCase()}
+            </span>
+          )}
+          <button onClick={handleClear} style={clearBtnStyle}>
+            Clear Chat
+          </button>
+        </div>
+      </div>
+
+      {/* Tool capabilities bar */}
+      {agentInfo && (
+        <div style={{ ...cardStyle, padding: '12px 16px', marginBottom: 16, display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'center' }}>
+          <span style={{ fontSize: 12, color: '#718096', fontWeight: 600, marginRight: 4 }}>Tools:</span>
+          {agentInfo.tools.map((tool) => (
+            <span key={tool} style={toolBadgeStyle}>
+              {tool}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {/* Chat messages */}
+      <div style={{ flex: 1, overflowY: 'auto', marginBottom: 16, paddingBottom: 8 }}>
+        {messages.length === 0 && !sending && (
+          <div style={{ ...cardStyle, textAlign: 'center', padding: 48, marginTop: 32 }}>
+            <div style={{ fontSize: 40, marginBottom: 16 }}>{'</>'}</div>
+            <h3 style={{ margin: '0 0 8px', color: '#2d3748' }}>Welcome to Cornerstone AI Agent</h3>
+            <p style={{ margin: 0, color: '#718096', fontSize: 14, maxWidth: 480, marginLeft: 'auto', marginRight: 'auto' }}>
+              Ask me to read files, write code, run commands, search your codebase, or manage your project.
+              I can help you build, debug, and maintain the Cornerstone Platform.
+            </p>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, justifyContent: 'center', marginTop: 20 }}>
+              {QUICK_PROMPTS.map((prompt) => (
+                <button
+                  key={prompt}
+                  onClick={() => setInput(prompt)}
+                  style={quickPromptStyle}
+                >
+                  {prompt}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {messages.map((msg) => (
+          <div key={msg.id} style={{ marginBottom: 16, display: 'flex', flexDirection: 'column', alignItems: msg.role === 'user' ? 'flex-end' : 'flex-start' }}>
+            <div
+              style={{
+                ...cardStyle,
+                maxWidth: '85%',
+                padding: '12px 16px',
+                background: msg.role === 'user' ? '#3182ce' : '#fff',
+                color: msg.role === 'user' ? '#fff' : '#2d3748',
+                borderRadius: msg.role === 'user' ? '16px 16px 4px 16px' : '16px 16px 16px 4px',
+              }}
+            >
+              <div style={{ fontSize: 11, fontWeight: 600, marginBottom: 4, opacity: 0.7 }}>
+                {msg.role === 'user' ? 'You' : 'Cornerstone AI'}
+              </div>
+              <div style={{ fontSize: 14, whiteSpace: 'pre-wrap', lineHeight: 1.6 }}>
+                {msg.content}
+              </div>
+            </div>
+
+            {/* Tool actions */}
+            {msg.toolActions && msg.toolActions.length > 0 && (
+              <div style={{ maxWidth: '85%', marginTop: 6 }}>
+                <button onClick={() => toggleTool(msg.id)} style={toolToggleStyle}>
+                  {expandedTools[msg.id] ? 'Hide' : 'Show'} {msg.toolActions.length} tool action{msg.toolActions.length > 1 ? 's' : ''}
+                </button>
+                {expandedTools[msg.id] && (
+                  <div style={{ marginTop: 6, display: 'flex', flexDirection: 'column', gap: 8 }}>
+                    {msg.toolActions.map((action, i) => (
+                      <div key={i} style={{ ...cardStyle, padding: '10px 14px', background: '#f7fafc', borderLeft: '3px solid #805ad5' }}>
+                        <div style={{ fontSize: 12, fontWeight: 700, color: '#805ad5', marginBottom: 4 }}>
+                          {action.tool}
+                        </div>
+                        <div style={{ fontSize: 12, color: '#4a5568', marginBottom: 4 }}>
+                          <strong>Input:</strong>{' '}
+                          <code style={{ background: '#edf2f7', padding: '1px 4px', borderRadius: 3, fontSize: 11 }}>
+                            {JSON.stringify(action.input).slice(0, 200)}
+                            {JSON.stringify(action.input).length > 200 ? '...' : ''}
+                          </code>
+                        </div>
+                        <div style={{ fontSize: 12, color: '#4a5568' }}>
+                          <strong>Output:</strong>
+                          <pre style={{ margin: '4px 0 0', fontSize: 11, background: '#edf2f7', padding: 8, borderRadius: 4, overflowX: 'auto', maxHeight: 200, whiteSpace: 'pre-wrap' }}>
+                            {action.output.slice(0, 1000)}
+                            {action.output.length > 1000 ? '\n...(truncated)' : ''}
+                          </pre>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
+
+            <div style={{ fontSize: 10, color: '#a0aec0', marginTop: 4, paddingLeft: 4, paddingRight: 4 }}>
+              {msg.timestamp.toLocaleTimeString()}
+            </div>
+          </div>
+        ))}
+
+        {sending && (
+          <div style={{ display: 'flex', alignItems: 'flex-start', marginBottom: 16 }}>
+            <div style={{ ...cardStyle, padding: '12px 16px', borderRadius: '16px 16px 16px 4px' }}>
+              <div style={{ fontSize: 11, fontWeight: 600, marginBottom: 4, color: '#718096' }}>Cornerstone AI</div>
+              <div style={{ display: 'flex', gap: 4, alignItems: 'center' }}>
+                <span style={dotStyle} />
+                <span style={{ ...dotStyle, animationDelay: '0.2s' }} />
+                <span style={{ ...dotStyle, animationDelay: '0.4s' }} />
+                <span style={{ fontSize: 13, color: '#718096', marginLeft: 8 }}>Thinking...</span>
+              </div>
+            </div>
+          </div>
+        )}
+
+        <div ref={bottomRef} />
+      </div>
+
+      {/* Input area */}
+      <form onSubmit={handleSend} style={{ display: 'flex', gap: 8, padding: '12px 0 16px', borderTop: '1px solid #e2e8f0' }}>
+        <input
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="Ask the Cornerstone AI Agent..."
+          disabled={sending}
+          style={{
+            flex: 1,
+            padding: '12px 16px',
+            border: '1px solid #e2e8f0',
+            borderRadius: 8,
+            fontSize: 14,
+            outline: 'none',
+            boxSizing: 'border-box',
+          }}
+        />
+        <button
+          type="submit"
+          disabled={sending || !input.trim()}
+          style={{
+            ...sendBtnStyle,
+            opacity: sending || !input.trim() ? 0.5 : 1,
+          }}
+        >
+          {sending ? 'Sending...' : 'Send'}
+        </button>
+      </form>
+
+      {/* Animations */}
+      <style>{`
+        @keyframes pulse {
+          0%, 100% { opacity: 0.3; }
+          50% { opacity: 1; }
+        }
+      `}</style>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Constants & Styles
+// ---------------------------------------------------------------------------
+
+const QUICK_PROMPTS = [
+  'Show me all Python files',
+  'What is the project structure?',
+  'Check git status',
+  'Read the main.py file',
+];
+
+const cardStyle: React.CSSProperties = {
+  background: '#fff',
+  borderRadius: 10,
+  boxShadow: '0 2px 12px rgba(0,0,0,0.06)',
+};
+
+const clearBtnStyle: React.CSSProperties = {
+  background: 'transparent',
+  border: '1px solid #e2e8f0',
+  color: '#718096',
+  padding: '6px 14px',
+  borderRadius: 6,
+  cursor: 'pointer',
+  fontSize: 13,
+  fontWeight: 500,
+};
+
+const toolBadgeStyle: React.CSSProperties = {
+  background: '#ebf4ff',
+  color: '#3182ce',
+  padding: '3px 10px',
+  borderRadius: 12,
+  fontSize: 11,
+  fontWeight: 600,
+};
+
+const toolToggleStyle: React.CSSProperties = {
+  background: 'transparent',
+  border: '1px solid #e9d8fd',
+  color: '#805ad5',
+  padding: '4px 12px',
+  borderRadius: 6,
+  cursor: 'pointer',
+  fontSize: 12,
+  fontWeight: 600,
+};
+
+const quickPromptStyle: React.CSSProperties = {
+  background: '#ebf4ff',
+  border: '1px solid #bee3f8',
+  color: '#2b6cb0',
+  padding: '6px 14px',
+  borderRadius: 16,
+  cursor: 'pointer',
+  fontSize: 13,
+  fontWeight: 500,
+};
+
+const sendBtnStyle: React.CSSProperties = {
+  background: '#3182ce',
+  color: '#fff',
+  border: 'none',
+  padding: '12px 24px',
+  borderRadius: 8,
+  cursor: 'pointer',
+  fontWeight: 600,
+  fontSize: 14,
+  whiteSpace: 'nowrap',
+};
+
+const dotStyle: React.CSSProperties = {
+  width: 8,
+  height: 8,
+  borderRadius: '50%',
+  background: '#805ad5',
+  animation: 'pulse 1.2s ease-in-out infinite',
+  display: 'inline-block',
+};

--- a/frontend/src/pages/SettingsPage.jsx
+++ b/frontend/src/pages/SettingsPage.jsx
@@ -1,0 +1,175 @@
+import { useEffect, useState } from "react";
+import { api } from "../lib/api.js";
+
+const cardStyle = { background: "#fff", borderRadius: 10, boxShadow: "0 2px 12px rgba(0,0,0,0.06)", padding: "20px 24px" };
+const inputStyle = { width: "100%", padding: "10px 14px", border: "1px solid #e2e8f0", borderRadius: 8, fontSize: 14, outline: "none", boxSizing: "border-box" };
+const textareaStyle = { ...inputStyle, minHeight: 100, resize: "vertical", fontFamily: "monospace", fontSize: 12 };
+const btnPrimary = { background: "#3182ce", color: "#fff", border: "none", padding: "10px 24px", borderRadius: 6, cursor: "pointer", fontWeight: 600, fontSize: 14 };
+const labelStyle = { fontSize: 12, color: "#718096", fontWeight: 600, display: "block", marginBottom: 4 };
+const colorInput = { width: 48, height: 36, border: "1px solid #e2e8f0", borderRadius: 6, cursor: "pointer", padding: 2 };
+
+export default function SettingsPage() {
+  const [settings, setSettings] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [sub, setSub] = useState(null);
+
+  useEffect(() => {
+    Promise.all([
+      api.getPlatformSettings().catch(() => ({})),
+      api.getSubscription().catch(() => null),
+    ]).then(([s, subscription]) => {
+      setSettings(s || {});
+      setSub(subscription);
+      setLoading(false);
+    });
+  }, []);
+
+  const handleSave = async () => {
+    setSaving(true);
+    setSaved(false);
+    try {
+      const res = await api.updatePlatformSettings(settings);
+      setSettings(res);
+      setSaved(true);
+      setTimeout(() => setSaved(false), 3000);
+    } catch (err) { alert(err.message || "Error saving settings"); }
+    finally { setSaving(false); }
+  };
+
+  const handleUpgrade = async () => {
+    try {
+      const res = await api.upgradeSubscription();
+      setSub(res);
+      alert("Upgraded to Pro!");
+    } catch (err) { alert(err.message || "Error upgrading"); }
+  };
+
+  const update = (key, val) => setSettings({ ...settings, [key]: val });
+
+  if (loading) return <div style={{ padding: 32, textAlign: "center", color: "#718096" }}>Loading settings...</div>;
+
+  return (
+    <div style={{ maxWidth: 960, margin: "0 auto", padding: 16 }}>
+      <h2 style={{ margin: "0 0 4px", color: "#2d3748", fontSize: 22 }}>Platform Settings</h2>
+      <p style={{ margin: "0 0 20px", color: "#718096", fontSize: 13 }}>White-label customization and subscription management</p>
+
+      {/* Subscription */}
+      <div style={{ ...cardStyle, marginBottom: 24 }}>
+        <h3 style={{ margin: "0 0 16px", color: "#2d3748", fontSize: 16 }}>Subscription</h3>
+        {sub ? (
+          <div style={{ display: "flex", gap: 20, alignItems: "center", flexWrap: "wrap" }}>
+            <div>
+              <span style={{ background: sub.tier === "free" ? "#ebf4ff" : sub.tier === "pro" ? "#f0fff4" : "#faf5ff", color: sub.tier === "free" ? "#3182ce" : sub.tier === "pro" ? "#276749" : "#6b46c1", padding: "4px 14px", borderRadius: 12, fontSize: 13, fontWeight: 700, textTransform: "uppercase" }}>{sub.tier}</span>
+            </div>
+            <div style={{ fontSize: 13, color: "#4a5568" }}>
+              <strong>{sub.messages_used}</strong> / {sub.messages_limit} messages used
+            </div>
+            <div style={{ width: 120, height: 8, background: "#e2e8f0", borderRadius: 4, overflow: "hidden" }}>
+              <div style={{ width: Math.min(100, (sub.messages_used / sub.messages_limit) * 100) + "%", height: "100%", background: (sub.messages_used / sub.messages_limit) > 0.8 ? "#e53e3e" : "#48bb78", borderRadius: 4 }} />
+            </div>
+            {sub.tier === "free" && <button onClick={handleUpgrade} style={btnPrimary}>Upgrade to Pro ($29/mo)</button>}
+          </div>
+        ) : <p style={{ color: "#a0aec0", fontSize: 13 }}>No subscription info available</p>}
+      </div>
+
+      {/* Branding */}
+      <div style={{ ...cardStyle, marginBottom: 24 }}>
+        <h3 style={{ margin: "0 0 16px", color: "#2d3748", fontSize: 16 }}>Branding</h3>
+        <div style={{ display: "flex", flexDirection: "column", gap: 14 }}>
+          <div>
+            <label style={labelStyle}>Platform Name</label>
+            <input value={settings.platform_name || ""} onChange={(e) => update("platform_name", e.target.value)} placeholder="NorthStar Platform" style={inputStyle} />
+          </div>
+          <div>
+            <label style={labelStyle}>Tagline</label>
+            <input value={settings.tagline || ""} onChange={(e) => update("tagline", e.target.value)} placeholder="AI-Powered Consulting Platform" style={inputStyle} />
+          </div>
+          <div>
+            <label style={labelStyle}>Logo URL</label>
+            <input value={settings.logo_url || ""} onChange={(e) => update("logo_url", e.target.value)} placeholder="https://example.com/logo.png" style={inputStyle} />
+          </div>
+          <div>
+            <label style={labelStyle}>Support Email</label>
+            <input value={settings.support_email || ""} onChange={(e) => update("support_email", e.target.value)} placeholder="support@yourplatform.com" style={inputStyle} />
+          </div>
+        </div>
+      </div>
+
+      {/* Colors */}
+      <div style={{ ...cardStyle, marginBottom: 24 }}>
+        <h3 style={{ margin: "0 0 16px", color: "#2d3748", fontSize: 16 }}>Theme Colors</h3>
+        <div style={{ display: "flex", gap: 24, flexWrap: "wrap" }}>
+          <div>
+            <label style={labelStyle}>Primary Color</label>
+            <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+              <input type="color" value={settings.primary_color || "#3182ce"} onChange={(e) => update("primary_color", e.target.value)} style={colorInput} />
+              <input value={settings.primary_color || "#3182ce"} onChange={(e) => update("primary_color", e.target.value)} style={{ ...inputStyle, width: 100 }} />
+            </div>
+          </div>
+          <div>
+            <label style={labelStyle}>Accent Color</label>
+            <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+              <input type="color" value={settings.accent_color || "#805ad5"} onChange={(e) => update("accent_color", e.target.value)} style={colorInput} />
+              <input value={settings.accent_color || "#805ad5"} onChange={(e) => update("accent_color", e.target.value)} style={{ ...inputStyle, width: 100 }} />
+            </div>
+          </div>
+          <div>
+            <label style={labelStyle}>Sidebar Background</label>
+            <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+              <input type="color" value={settings.sidebar_bg || "#1a202c"} onChange={(e) => update("sidebar_bg", e.target.value)} style={colorInput} />
+              <input value={settings.sidebar_bg || "#1a202c"} onChange={(e) => update("sidebar_bg", e.target.value)} style={{ ...inputStyle, width: 100 }} />
+            </div>
+          </div>
+          <div>
+            <label style={labelStyle}>Sidebar Text</label>
+            <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+              <input type="color" value={settings.sidebar_text || "#e2e8f0"} onChange={(e) => update("sidebar_text", e.target.value)} style={colorInput} />
+              <input value={settings.sidebar_text || "#e2e8f0"} onChange={(e) => update("sidebar_text", e.target.value)} style={{ ...inputStyle, width: 100 }} />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Custom CSS */}
+      <div style={{ ...cardStyle, marginBottom: 24 }}>
+        <h3 style={{ margin: "0 0 16px", color: "#2d3748", fontSize: 16 }}>Custom CSS</h3>
+        <textarea value={settings.custom_css || ""} onChange={(e) => update("custom_css", e.target.value)} placeholder="/* Add custom CSS overrides here */" style={textareaStyle} />
+      </div>
+
+      {/* Feature toggles */}
+      <div style={{ ...cardStyle, marginBottom: 24 }}>
+        <h3 style={{ margin: "0 0 16px", color: "#2d3748", fontSize: 16 }}>Feature Toggles</h3>
+        <div style={{ display: "flex", gap: 20, flexWrap: "wrap" }}>
+          <label style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 13, color: "#4a5568", cursor: "pointer" }}>
+            <input type="checkbox" checked={settings.enable_marketplace !== false} onChange={(e) => update("enable_marketplace", e.target.checked)} /> Enable Marketplace
+          </label>
+          <label style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 13, color: "#4a5568", cursor: "pointer" }}>
+            <input type="checkbox" checked={settings.enable_analytics !== false} onChange={(e) => update("enable_analytics", e.target.checked)} /> Enable Analytics
+          </label>
+        </div>
+      </div>
+
+      {/* Preview */}
+      <div style={{ ...cardStyle, marginBottom: 24, background: settings.sidebar_bg || "#1a202c", color: settings.sidebar_text || "#e2e8f0" }}>
+        <h3 style={{ margin: "0 0 12px", fontSize: 16, color: settings.sidebar_text || "#e2e8f0" }}>Sidebar Preview</h3>
+        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+          <div style={{ fontWeight: 700, fontSize: 16, color: settings.primary_color || "#3182ce" }}>{settings.platform_name || "NorthStar Platform"}</div>
+          <div style={{ fontSize: 11, opacity: 0.7 }}>{settings.tagline || "AI-Powered Consulting Platform"}</div>
+          <div style={{ marginTop: 8, display: "flex", flexDirection: "column", gap: 4 }}>
+            {["Dashboard", "Leads", "Agent", "Analytics", "Marketplace", "Settings"].map((item) => (
+              <div key={item} style={{ padding: "6px 12px", borderRadius: 6, fontSize: 13, background: item === "Settings" ? (settings.accent_color || "#805ad5") + "33" : "transparent", color: item === "Settings" ? (settings.accent_color || "#805ad5") : (settings.sidebar_text || "#e2e8f0"), cursor: "pointer" }}>{item}</div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Save */}
+      <div style={{ display: "flex", gap: 12, alignItems: "center" }}>
+        <button onClick={handleSave} disabled={saving} style={{ ...btnPrimary, opacity: saving ? 0.6 : 1 }}>{saving ? "Saving..." : "Save Settings"}</button>
+        {saved && <span style={{ fontSize: 13, color: "#48bb78", fontWeight: 600 }}>Settings saved successfully!</span>}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -367,3 +367,36 @@ export const getLeaderboard = (limit = 10) =>
 
 export const getRevenueModels = () =>
   api.get('/rewards/revenue-models').then((r) => r.data);
+
+// ─── Cornerstone AI Agent ────────────────────────────────────────────────────
+
+export interface AgentToolAction {
+  tool: string;
+  input: Record<string, any>;
+  output: string;
+}
+
+export interface AgentChatResponse {
+  response: string;
+  tool_actions: AgentToolAction[];
+  history: Array<Record<string, any>>;
+}
+
+export interface AgentInfo {
+  name: string;
+  description: string;
+  workspace: string;
+  tools: string[];
+  status: string;
+}
+
+export const sendAgentMessage = (
+  message: string,
+  history?: Array<Record<string, any>>,
+) =>
+  api
+    .post<AgentChatResponse>('/agent/chat', { message, history })
+    .then((r) => r.data);
+
+export const getAgentInfo = () =>
+  api.get<AgentInfo>('/agent/info').then((r) => r.data);

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -15,8 +15,7 @@ export default defineConfig({
       "/research": "http://localhost:8000",
       "/business-ideas": "http://localhost:8000",
       "/rewards": "http://localhost:8000",
-      "/agent/chat": "http://localhost:8000",
-      "/agent/info": "http://localhost:8000",
+      "/agent": "http://localhost:8000",
     },
   },
 });

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -15,6 +15,7 @@ export default defineConfig({
       "/research": "http://localhost:8000",
       "/business-ideas": "http://localhost:8000",
       "/rewards": "http://localhost:8000",
+      "/agent": "http://localhost:8000",
     },
   },
 });

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -15,7 +15,8 @@ export default defineConfig({
       "/research": "http://localhost:8000",
       "/business-ideas": "http://localhost:8000",
       "/rewards": "http://localhost:8000",
-      "/agent": "http://localhost:8000",
+      "/agent/chat": "http://localhost:8000",
+      "/agent/info": "http://localhost:8000",
     },
   },
 });


### PR DESCRIPTION
## Summary

Major feature expansion adding 9 capabilities to make the platform more investable:

**Backend (4 new DB models, rewritten agent service & router):**
- **Multi-model support**: Anthropic Claude, OpenAI GPT-4, Google Gemini (via OpenAI-compatible API)
- **Streaming responses**: SSE endpoint at `POST /agent/chat/stream`
- **Audit logging**: Every agent interaction tracked with tokens, latency, tool actions
- **Approval workflows**: Destructive tools (write_file, delete_file, run_command, create_directory) can require user confirmation
- **Usage-based pricing**: Free (50 msgs/mo), Pro (unlimited), Enterprise tiers with per-user tracking
- **Sandboxed execution**: Improved command blocklist with regex patterns

**Frontend (3 new pages, updated agent UI):**
- **CornerstoneAgent**: Provider/model selector, approval dialogs, streaming toggle, usage meter, token counts
- **AnalyticsDashboard**: Messages/day chart, tool usage bars, model usage, audit log table
- **AgentMarketplace**: Browse/create/delete custom agent configurations
- **SettingsPage**: White-label branding (name, colors, logo, custom CSS), subscription management, sidebar preview

### Updates since last revision

Fixed 6 frontend↔backend integration issues discovered during end-to-end testing:

1. **Streaming SSE field mismatch** — Frontend now checks `parsed.content` in addition to `parsed.token` to handle the backend's `text_delta` events
2. **Token display** — Frontend constructs `{input_tokens, output_tokens}` from backend's `tokens_input`/`tokens_output` fields (previously looked for a `tokens` object that didn't exist)
3. **Analytics field mapping** — Frontend now maps `messages_by_day`→dailyMessages, `top_tools`→toolUsage, `messages_by_provider`→modelUsage with fallbacks
4. **Approval response** — Backend `POST /agent/approve` now returns `response` and `tool_actions` fields alongside `status` and `results`
5. **Settings save** — Backend `PUT /agent/settings` now returns the full `PlatformSettingsResponse` instead of `{"status": "updated"}`, preventing the form from reverting to defaults
6. **Analytics endpoint crash** — Replaced `sqlfunc.cast(created_at, text())` with Python-based `Counter` date grouping to avoid SQLAlchemy compatibility errors

**Verified via browser testing:**

| Test | Result |
|------|--------|
| Agent chat + token display ("Tokens: 1028 in / 37 out") | ✅ |
| Analytics dashboard (messages, tools, model usage, daily chart) | ✅ |
| Settings save persistence (name persists after save) | ✅ |
| Approval workflow (approve → "Executed write_file: ...") | ✅ |

![Token display after agent chat](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNmZmNjgwMGMzMmNjNDE4NmJjNDczZTk1OGJiNTk0YTYiLCJ1c2VyX2lkIjoiZ2l0aHVifDI2NDg3NzAzMSIsImJ1Y2tldF9uYW1lIjoiZGV2aW5hdHRhY2htZW50cyIsImJ1Y2tldF9rZXkiOiJhdHRhY2htZW50c19wcml2YXRlL29yZy02ZmY2ODAwYzMyY2M0MTg2YmM0NzNlOTU4YmI1OTRhNi9lNzA3YWEyMy1lNmYyLTQwY2YtOWRlYy00YjliM2I4NDRkOTgiLCJpYXQiOjE3NzQ2NzY2NzMsImV4cCI6MTc3NTI4MTQ3M30.rbmEGxzrg2mgJc_oBmARNDWTg92z-IRFYuhwZPJ9cBU)
![Analytics dashboard with data](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNmZmNjgwMGMzMmNjNDE4NmJjNDczZTk1OGJiNTk0YTYiLCJ1c2VyX2lkIjoiZ2l0aHVifDI2NDg3NzAzMSIsImJ1Y2tldF9uYW1lIjoiZGV2aW5hdHRhY2htZW50cyIsImJ1Y2tldF9rZXkiOiJhdHRhY2htZW50c19wcml2YXRlL29yZy02ZmY2ODAwYzMyY2M0MTg2YmM0NzNlOTU4YmI1OTRhNi9mMjNkYTg2MC0wNTBmLTQwZWUtYmMyMy04NDYxZTU5OWRhYWUiLCJpYXQiOjE3NzQ2NzY2NzMsImV4cCI6MTc3NTI4MTQ3M30.FBPCUc9HZf7ED5ZAEQVV9e-cSZ_4ra1E8lanQWfJi0k)
![Settings persistence](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNmZmNjgwMGMzMmNjNDE4NmJjNDczZTk1OGJiNTk0YTYiLCJ1c2VyX2lkIjoiZ2l0aHVifDI2NDg3NzAzMSIsImJ1Y2tldF9uYW1lIjoiZGV2aW5hdHRhY2htZW50cyIsImJ1Y2tldF9rZXkiOiJhdHRhY2htZW50c19wcml2YXRlL29yZy02ZmY2ODAwYzMyY2M0MTg2YmM0NzNlOTU4YmI1OTRhNi9jZDhjN2IwNy05OWE2LTQ4OTctYmQ4Ny0zZWRhODcxZWM4NTMiLCJpYXQiOjE3NzQ2NzY2NzMsImV4cCI6MTc3NTI4MTQ3M30.Ajl4UmtjhnccCEyXi21sxShR1koA3XT-i-xJ20bL1dk)
![Approval workflow](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctNmZmNjgwMGMzMmNjNDE4NmJjNDczZTk1OGJiNTk0YTYiLCJ1c2VyX2lkIjoiZ2l0aHVifDI2NDg3NzAzMSIsImJ1Y2tldF9uYW1lIjoiZGV2aW5hdHRhY2htZW50cyIsImJ1Y2tldF9rZXkiOiJhdHRhY2htZW50c19wcml2YXRlL29yZy02ZmY2ODAwYzMyY2M0MTg2YmM0NzNlOTU4YmI1OTRhNi82ZTBiOWZjYy01NGYxLTQzMTAtOTNjYy0xYmQ2NDU4NzY3NTkiLCJpYXQiOjE3NzQ2NzY2NzQsImV4cCI6MTc3NTI4MTQ3NH0.whM-Ss2JgAYQ-zsy8gcrKI6W1p1nKMGPDxGh7jw86pQ)

## Review & Testing Checklist for Human

- [ ] **Security: `shell=True` command execution** — `agent_service.py` runs user-influenced commands via `subprocess.run(command, shell=True)`. The blocklist approach (`BLOCKED_PATTERNS`) is bypassable (e.g., encoding tricks, path traversal). Verify this is acceptable for your threat model or consider switching to `shell=False` with argument splitting.
- [ ] **Security: `/agent/approve` endpoint is stateless** — The approval workflow doesn't persist pending approvals server-side. A client can POST arbitrary tool executions (including `write_file`, `run_command`) to this endpoint without them ever being "pending." This effectively allows unauthenticated tool execution for any logged-in user. Consider adding server-side approval state.
- [ ] **Security: `/agent/settings` has no admin check** — Any authenticated user can modify platform-wide branding/settings. Verify this is intended or add role-based access control.
- [ ] **Streaming endpoint bypasses usage limits and audit logging** — `POST /agent/chat/stream` does not check subscription limits, record audit logs, or track usage, unlike `POST /agent/chat`. Users could bypass limits by toggling "Streaming" on.
- [ ] **No Alembic migrations** — New models are created via `Base.metadata.create_all()` on startup instead of proper migrations. This works for fresh databases but will silently skip schema changes on existing ones.

### Test Plan
1. Set `ANTHROPIC_API_KEY` in backend `.env`, start backend + frontend
2. Navigate to `/agent` — verify provider/model dropdowns, approval checkbox, streaming toggle, and usage meter render
3. Send a message with streaming **off** — verify token counts appear below the response (e.g., "Tokens: X in / Y out")
4. Send a message with "Require approval" checked that triggers a destructive tool (e.g., "Write hello to test.txt") — verify approval dialog appears, then approve and confirm the response shows "Executed write_file: ..."
5. Visit `/analytics` — verify Messages Today, Tool Usage, Model Usage, and Messages per Day all show data (not "No data yet")
6. Visit `/marketplace` — create a custom agent config, verify it appears in the list
7. Visit `/settings` — change platform name, save, verify the field **retains the new value** (does not revert to defaults)
8. Test the subscription upgrade flow on `/settings`

### Notes
- The subscription "upgrade" endpoint is a stub — it changes the tier without payment integration (Stripe IDs are stored but not used)
- Google Gemini support requires `GOOGLE_API_KEY` env var and uses Google's OpenAI-compatible endpoint
- `custom_css` in white-label settings is stored raw — no sanitization is applied before potential rendering (XSS risk if displayed)
- Analytics date grouping uses `str(timestamp)[:10]` in Python — works for standard datetime formats but is fragile
- No automated tests are included in this PR; all verification was manual via browser

Link to Devin session: https://app.devin.ai/sessions/d5c704ef8c9e431eb09a1f5fe094b7b4
Requested by: @bei22002-cpu